### PR TITLE
Feature/student profile layout

### DIFF
--- a/frontend/src/components/Page.vue
+++ b/frontend/src/components/Page.vue
@@ -29,7 +29,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .page {
   width: 100%;
 

--- a/frontend/src/components/StudentHistory/StudentHistory.vue
+++ b/frontend/src/components/StudentHistory/StudentHistory.vue
@@ -1,53 +1,47 @@
-
 <template>
-    <div class="card">
-        <header> HISTORY </header>
-        <Timeline :items="items"></Timeline>
-    </div>
+  <div class="card">
+    <header>HISTORY</header>
+    <Timeline :items="items"></Timeline>
+  </div>
 </template>
 
 <script>
-import Timeline from "./Timeline.vue"
+import Timeline from "./Timeline.vue";
 export default {
-    name: 'StudentHistory',
-    components: {
-        Timeline
+  name: "StudentHistory",
+  components: {
+    Timeline,
+  },
+  props: {
+    items: {
+      type: Array,
+      default: () => [],
+      /*
+       * item: { date: Date, description: String, status: Number }
+       */
     },
-    props: {
-        items: {
-            type: Array,
-            default: () => []
-            /*
-            * item: { date: Date, description: String, status: Number }
-            */ 
-        }
-    },
-}
-    
+  },
+};
 </script>
 
 <style>
 .card {
-    position:absolute;
-    width: 448px;
-    height: 600px;
-    padding: 32px;
+  padding: 32px;
 }
 header {
-    margin-bottom: 12px;
+  margin-bottom: 12px;
 
-    /* Roboto 12PX REGULAR */
+  /* Roboto 12PX REGULAR */
 
-    font-family: Roboto, sans-serif;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 12px;
-    line-height: 18px;
-    letter-spacing: 1.2px;
-    text-transform: uppercase;
-    
+  font-family: Roboto, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 12px;
+  line-height: 18px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
 
-    /* Dark Grey */
-    color: #59666E;
-    }
+  /* Dark Grey */
+  color: #59666e;
+}
 </style>

--- a/frontend/src/components/StudentProfileCard.vue
+++ b/frontend/src/components/StudentProfileCard.vue
@@ -1,56 +1,54 @@
 <template>
   <div class="card">
-    <div class="card-content">
-      <div class="edit-container">Edit</div>
-      <div class="student-grid">
-        <img src="../assets/images/student.png" />
-        <div class="student-label">Student</div>
-        <div class="student-main">{{ studentInfo.studentName }}</div>
-        <div class="student-main">{{ studentInfo.studentContact }}</div>
-        <div>
-          <div class="student-label-small padding-large">Date Joined</div>
-          <div class="student-detail">{{ studentInfo.dateJoined }}</div>
+    <div class="edit-container">Edit</div>
+    <div class="student-grid">
+      <img src="../assets/images/student.png" />
+      <div class="student-label">Student</div>
+      <div class="student-main">{{ studentInfo.studentName }}</div>
+      <div class="student-main">{{ studentInfo.studentContact }}</div>
+      <div>
+        <div class="student-label-small padding-large">Date Joined</div>
+        <div class="student-detail">{{ studentInfo.dateJoined }}</div>
+      </div>
+      <div>
+        <div class="student-label-small padding-large">Source</div>
+        <div class="student-detail">{{ studentInfo.source }}</div>
+      </div>
+      <div>
+        <div class="student-label-small padding-small">Native Language</div>
+        <div class="student-detail">{{ studentInfo.nativeLanguage }}</div>
+      </div>
+      <div>
+        <div class="student-label-small padding-small">
+          English Proficiency
         </div>
         <div>
-          <div class="student-label-small padding-large">Source</div>
-          <div class="student-detail">{{ studentInfo.source }}</div>
-        </div>
-        <div>
-          <div class="student-label-small padding-small">Native Language</div>
-          <div class="student-detail">{{ studentInfo.nativeLanguage }}</div>
-        </div>
-        <div>
-          <div class="student-label-small padding-small">
-            English Proficiency
-          </div>
-          <div>
-            <b-select
-              v-if="studentInfo.status === 'Screening'"
-              placeholder="Select Proficiency"
+          <b-select
+            v-if="studentInfo.status === 'Screening'"
+            placeholder="Select Proficiency"
+          >
+            <option value="No">No - Unable to understand at all</option>
+            <option value="Little"
+              >Little - Able to understand simple words</option
             >
-              <option value="No">No - Unable to understand at all</option>
-              <option value="Little"
-                >Little - Able to understand simple words</option
-              >
-              <option value="Simple"
-                >Simple - Able to speak full sentences</option
-              >
-              <option value="Intermediate"
-                >Intermediate - Able to carry conversations</option
-              >
-            </b-select>
-            <div v-else class="student-detail">
-              {{ studentInfo.proficiencyLevel }}
-            </div>
+            <option value="Simple"
+              >Simple - Able to speak full sentences</option
+            >
+            <option value="Intermediate"
+              >Intermediate - Able to carry conversations</option
+            >
+          </b-select>
+          <div v-else class="student-detail">
+            {{ studentInfo.proficiencyLevel }}
           </div>
         </div>
       </div>
+    </div>
 
-      <hr />
-      <div class="notes-label">Notes</div>
-      <div class="notes-text">
-        {{ studentInfo.notes }}
-      </div>
+    <hr />
+    <div class="notes-label">Notes</div>
+    <div class="notes-text">
+      {{ studentInfo.notes }}
     </div>
   </div>
 </template>
@@ -79,6 +77,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.card {
+  width: 100%;
+}
 .edit-container {
   text-align: right;
   color: #00488f;

--- a/frontend/src/components/statusCards/StatusCardDroppedOut.vue
+++ b/frontend/src/components/statusCards/StatusCardDroppedOut.vue
@@ -1,26 +1,24 @@
 <template>
   <div class="status-container">
     <div class="card">
-      <div class="card-content">
-        <div class="card-status-details">
-          <div class="content">
-            <div class="content-title">STATUS</div>
-            <b-taglist>
-              <b-tag type="is-danger is-light" size="is-large"
-                >&#9679; Dropped Out</b-tag
-              >
-            </b-taglist>
-          </div>
-          <div class="content">
-            <div class="content-title">REASON</div>
-            <p>{{ reason }}</p>
-          </div>
+      <div class="card-status-details">
+        <div class="content">
+          <div class="content-title">STATUS</div>
+          <b-taglist>
+            <b-tag type="is-danger is-light" size="is-medium"
+              >&#9679; Dropped Out</b-tag
+            >
+          </b-taglist>
         </div>
         <div class="content">
-          <div class="content-title">ACTION</div>
-          <div class="buttons">
-            <Button label="Reactivate for Matching" />
-          </div>
+          <div class="content-title">REASON</div>
+          <p>{{ reason }}</p>
+        </div>
+      </div>
+      <div class="content">
+        <div class="content-title">ACTION</div>
+        <div class="buttons">
+          <Button label="Reactivate for Matching" />
         </div>
       </div>
     </div>
@@ -44,15 +42,8 @@ export default {
 </script>
 
 <style scoped>
-.status-container {
-  width: 448px;
-  height: 228px;
-}
 .status-container .card {
   border-radius: 4px;
-}
-.card-content {
-  padding: 32px;
 }
 .card-status-details {
   display: flex;

--- a/frontend/src/components/statusCards/StatusCardMatched.vue
+++ b/frontend/src/components/statusCards/StatusCardMatched.vue
@@ -1,28 +1,26 @@
 <template>
   <div class="status-container">
     <div class="card">
-      <div class="card-content">
-        <div class="card-status-details">
-          <div class="content">
-            <div class="content-title">STATUS</div>
-            <b-taglist>
-              <b-tag type="is-success is-light" size="is-large"
-                >&#9679; Matched</b-tag
-              >
-            </b-taglist>
-          </div>
-          <div class="content">
-            <div class="content-title">MATCHED TO TEACHER</div>
-            <p>{{ teacherName }}</p>
-          </div>
-        </div>
-
+      <div class="card-status-details">
         <div class="content">
-          <div class="content-title">ACTION</div>
-          <div class="buttons">
-            <Button label="Drop Out" />
-            <Button label="View Match" solid />
-          </div>
+          <div class="content-title">STATUS</div>
+          <b-taglist>
+            <b-tag type="is-success is-light" size="is-medium"
+              >&#9679; Matched</b-tag
+            >
+          </b-taglist>
+        </div>
+        <div class="content">
+          <div class="content-title">MATCHED TO TEACHER</div>
+          <p>{{ teacherName }}</p>
+        </div>
+      </div>
+
+      <div class="content">
+        <div class="content-title">ACTION</div>
+        <div class="buttons">
+          <Button label="Drop Out" />
+          <Button label="View Match" solid />
         </div>
       </div>
     </div>
@@ -46,15 +44,8 @@ export default {
 </script>
 
 <style scoped>
-.status-container {
-  width: 448px;
-  height: 228px;
-}
 .status-container .card {
   border-radius: 4px;
-}
-.card-content {
-  padding: 32px;
 }
 .card-status-details {
   display: flex;

--- a/frontend/src/components/statusCards/StatusCardScreening.vue
+++ b/frontend/src/components/statusCards/StatusCardScreening.vue
@@ -1,21 +1,19 @@
 <template>
   <div class="status-container">
     <div class="card">
-      <div class="card-content">
-        <div class="content">
-          <div class="content-title">STATUS</div>
-          <b-taglist>
-            <b-tag type="is-info is-light" size="is-large"
-              >&#9679; Screening</b-tag
-            >
-          </b-taglist>
-        </div>
-        <div class="content">
-          <div class="content-title">ACTION</div>
-          <div class="buttons">
-            <Button label="Drop Out" />
-            <Button label="Ready to Match" />
-          </div>
+      <div class="content">
+        <div class="content-title">STATUS</div>
+        <b-taglist>
+          <b-tag type="is-info is-light" size="is-medium"
+            >&#9679; Screening</b-tag
+          >
+        </b-taglist>
+      </div>
+      <div class="content">
+        <div class="content-title">ACTION</div>
+        <div class="buttons">
+          <Button label="Drop Out" />
+          <Button label="Ready to Match" />
         </div>
       </div>
     </div>
@@ -33,15 +31,8 @@ export default {
 </script>
 
 <style scoped>
-.status-container {
-  width: 448px;
-  height: 228px;
-}
 .status-container .card {
   border-radius: 4px;
-}
-.card-content {
-  padding: 32px;
 }
 .content {
   font-size: 12px;

--- a/frontend/src/components/statusCards/StatusCardUnmatched.vue
+++ b/frontend/src/components/statusCards/StatusCardUnmatched.vue
@@ -1,21 +1,19 @@
 <template>
   <div class="status-container">
     <div class="card">
-      <div class="card-content">
-        <div class="content">
-          <div class="content-title">STATUS</div>
-          <b-taglist>
-            <b-tag type="is-warning is-light" size="is-large"
-              >&#9679; Unmatched</b-tag
-            >
-          </b-taglist>
-        </div>
-        <div class="content">
-          <div class="content-title">ACTION</div>
-          <div class="buttons">
-            <Button label="Drop Out" />
-            <Button label="Select Match" solid />
-          </div>
+      <div class="content">
+        <div class="content-title">STATUS</div>
+        <b-taglist>
+          <b-tag type="is-warning is-light" size="is-medium"
+            >&#9679; Unmatched</b-tag
+          >
+        </b-taglist>
+      </div>
+      <div class="content">
+        <div class="content-title">ACTION</div>
+        <div class="buttons">
+          <Button label="Drop Out" />
+          <Button label="Select Match" solid />
         </div>
       </div>
     </div>
@@ -33,15 +31,8 @@ export default {
 </script>
 
 <style scoped>
-.status-container {
-  width: 448px;
-  height: 228px;
-}
 .status-container .card {
   border-radius: 4px;
-}
-.card-content {
-  padding: 32px;
 }
 .content {
   font-size: 12px;

--- a/frontend/src/pages/StudentProfile.vue
+++ b/frontend/src/pages/StudentProfile.vue
@@ -1,10 +1,17 @@
 <template>
   <Page blueBg>
     <div class="student-profile-container">
-      <section>Profile Details</section>
-      <div>
+      <StudentProfileCard />
+      <div class="student-profile-right">
         <section>Status</section>
-        <section>History</section>
+        <section class="student-history-section">
+          <StudentHistory
+            v-bind:items="[
+              { date: '2020-01-01', description: 'Joined MadWish', status: 1 },
+              { date: '2020-01-01', description: 'Joined MadWish', status: 3 },
+            ]"
+          />
+        </section>
       </div>
     </div>
   </Page>
@@ -12,11 +19,15 @@
 
 <script>
 import Page from "../components/Page.vue";
+import StudentProfileCard from "../components/StudentProfileCard.vue";
+import StudentHistory from "../components/StudentHistory/StudentHistory.vue";
 
 export default {
   name: "StudentProfile",
   components: {
     Page,
+    StudentProfileCard,
+    StudentHistory,
   },
 };
 </script>
@@ -24,5 +35,19 @@ export default {
 <style lang="scss">
 .student-profile-container {
   display: flex;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 14px;
+  min-height: calc(100vh - 48px);
+}
+.student-profile-right {
+  display: flex;
+  flex-direction: column;
+}
+.student-history-section {
+  padding-top: 24px;
+  padding-left: 24px;
+  display: flex;
+  flex: 1;
 }
 </style>

--- a/frontend/src/pages/StudentProfile.vue
+++ b/frontend/src/pages/StudentProfile.vue
@@ -1,9 +1,26 @@
 <template>
   <Page blueBg>
     <div class="student-profile-container">
-      <StudentProfileCard />
+      <div class="student-profile-left">
+        <StudentProfileCard
+          v-bind:studentInfo="{
+            studentName: studentData.FirstName + ' ' + studentData.LastName,
+            studentContact: studentData.PhoneNumber,
+            source: studentData.Source,
+            nativeLanguage: studentData.nativeLanguage.NativeLanguage,
+            notes: studentData.Notes,
+            status: studentData.status.Description,
+            proficiencyLevel: studentData.EnglishProficiency,
+          }"
+        />
+      </div>
       <div class="student-profile-right">
-        <section>Status</section>
+        <section class="student-status-section">
+          <StatusCardScreening v-if="studentData.status.StatusID === 1" />
+          <StatusCardUnmatched v-if="studentData.status.StatusID === 2" />
+          <StatusCardMatched v-if="studentData.status.StatusID === 3" />
+          <StatusCardDroppedOut v-if="studentData.status.StatusID === 4" />
+        </section>
         <section class="student-history-section">
           <StudentHistory
             v-bind:items="[
@@ -21,6 +38,10 @@
 import Page from "../components/Page.vue";
 import StudentProfileCard from "../components/StudentProfileCard.vue";
 import StudentHistory from "../components/StudentHistory/StudentHistory.vue";
+import StatusCardMatched from "../components/statusCards/StatusCardMatched.vue";
+import StatusCardDroppedOut from "../components/statusCards/StatusCardDroppedOut.vue";
+import StatusCardScreening from "../components/statusCards/StatusCardScreening.vue";
+import StatusCardUnmatched from "../components/statusCards/StatusCardUnmatched.vue";
 
 export default {
   name: "StudentProfile",
@@ -28,11 +49,37 @@ export default {
     Page,
     StudentProfileCard,
     StudentHistory,
+    StatusCardMatched,
+    StatusCardDroppedOut,
+    StatusCardScreening,
+    StatusCardUnmatched,
+  },
+  data: function() {
+    return {
+      // Dummy data. Should be empty data once API is integrated
+      studentData: {
+        StudentID: 1,
+        PhoneNumber: "87654321",
+        FirstName: "Cat",
+        LastName: "Catt",
+        Source: "Rotary",
+        nativeLanguage: {
+          NativeLanguageID: 1,
+          NativeLanguage: "Bangla",
+        },
+        EnglishProficiency: "Intermediate",
+        Notes: "Notes",
+        status: {
+          StatusID: 1,
+          Description: "Screening",
+        },
+      },
+    };
   },
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .student-profile-container {
   display: flex;
   padding-top: 4px;
@@ -40,9 +87,17 @@ export default {
   padding-left: 14px;
   min-height: calc(100vh - 48px);
 }
+.student-profile-left {
+  display: flex;
+  flex: 1;
+}
 .student-profile-right {
   display: flex;
   flex-direction: column;
+  padding-right: 14px;
+}
+.student-status-section {
+  padding-left: 24px;
 }
 .student-history-section {
   padding-top: 24px;


### PR DESCRIPTION
Added the student profile page for layout of the 3 cards (student profile details, student status and history). Added dummy props that will be updated once API is integrated. 

To render, need to add a new profile in App.vue (e.g. { id: 6, label: 'Temp, to: '/student/1', active: false  }) otherwise it won't link to the page properly. 