### PR TITLE
Setup configuration for production DB

### DIFF
--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -1,22 +1,22 @@
-require('dotenv').config()
+require("dotenv").config();
 
 module.exports = {
   development: {
-    client: 'pg',
+    client: "pg",
     useNullAsDefault: true,
     connection: {
-      user: process.env.DB_USERNAME || 'postgres',
+      user: process.env.DB_USERNAME || "postgres",
       password: process.env.DB_PASSWORD,
-      database: 'irrc_development',
+      database: "irrc_development",
     },
   },
   test: {
-    client: 'pg',
+    client: "pg",
     useNullAsDefault: true,
     connection: {
-      user: process.env.DB_USERNAME || 'postgres',
+      user: process.env.DB_USERNAME || "postgres",
       password: process.env.DB_PASSWORD,
-      database: 'irrc_test',
+      database: "irrc_test",
     },
   },
-}
+};

--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -19,4 +19,15 @@ module.exports = {
       database: "irrc_test",
     },
   },
+  production: {
+    client: "pg",
+    useNullAsDefault: true,
+    connection: process.env.DATABASE_URL,
+    migrations: {
+      directory: "./migrations",
+    },
+    seeds: {
+      directory: "./seeds",
+    },
+  },
 };


### PR DESCRIPTION
Just adds the config for the prod DB that is on Heroku. First commit is the Prettier diff, now that we are on a shared config. Second commit is the actual addition. The `DATABASE_URL` variable will only be available on Heroku, and is only for prod DB access, so we won't be adding it to our `.env.sample`.