### PR TITLE
Added travis script for basic CI and deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - 12
+install:
+  - "npm ci"
+script:
+  - "npm run build"
+deploy:
+  - provider: heroku
+    app: irrc-app
+    edge: true # opt in to dpl v2
+    api_key:
+      secure: azvganM1nXOrh9nOuqHDujoQ6CfyEWg3PWiaIoHbbN0y3JU73aicP1GiD6yyPH7W8fZIebPL2DmB+No8gYx0YRhpigsZtTCkPFPyM3DPkCteg1DJN4kZrzPuO05X1Sq5HCzZnshPL6TnIUO3gOx6t53BeXIZxsRjLahG6xJFohCvo9JLmlYIN9FkreH4gdkcDHAf+6Abt1PPcaieA37GTJqRdZGH7GFfzYUiS23K81mkCasBqrkgf4NxgYXOniJgBDzuSqFHWU5UKDwwyNWKEGquGSPC5WF1waT40s9Fy5AmW7JV7hQFtwzzj9Bkwe+3fCHG/Qvo7CmQ9ukUNUDCEx0LLZ0AiGUCEZV9wp/0ScTA7aagV9b4TmFLgUUgI90gGGqplY9nqRuxbu8DLC6FurDeJFrfMgLvmopRbO1UH9wv7AUZek2KmmqBleTzIvB2riU4wBP8nTalEAM1fI/fGOzT2tMiApvc//eVdVUzHBS0HGoaH1/EW/f7oWhYsYTZPGerIGKdvXHSt8E0UAbPpZ69uwEPLyQVJDC6iVvwyfREJ4PMnDee12MrsOLT+GZ7Hss8YGkxcQCRWK+3ufPAFqlpXZ2VFgXiyxsr7G7H/kTlyhd/jCwGVtwXFqrs9KkhQP2KPjADH08KB9EEpU4h99S4p6wLKhmIPtsqf/LLlZU= # Encrypted, only works in Travis CI
+    on:
+      branch: master

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "install.frontend": "npm --prefix frontend install",
     "install.backend": "npm --prefix backend install",
+    "build": "npm run --prefix frontend build",
+    "start": "npm run --prefix backend db:migrate && npm run --prefix backend start",
     "postinstall": "npm run clean && concurrently \"npm run install.frontend\" \"npm run install.backend\"",
     "serve": "concurrently \"npm --prefix frontend serve\"",
     "clean": "concurrently \"rm -rf frontend/node_modules\"  \"rm -rf backend/node_modules\""


### PR DESCRIPTION
- Added travis file for deployment
  - Note the deploy api_key is encrypted and only works on Travis CI, and [it is OK to check it in](https://docs.travis-ci.com/user/deployment-v2/providers/heroku/).
- Added `build` and `start` scripts to the root `package.json`, which is needed for the Heroku deployment/app start.

The deployed app will have no frontend until #21 and #22 are merged, and will not be able to connect to the database until #23 is merged.