### PR TITLE
[irrc-71] validations to status updates in backend

### DIFF
--- a/backend/src/routes/statusUpdates.js
+++ b/backend/src/routes/statusUpdates.js
@@ -16,25 +16,25 @@ router.post('/', async (req, res) => {
   delete req.body.PrevStatusString
   delete req.body.NextStatusString
 
-  if (prevStatus.StatusID == nextStatus.StatusID) {
+  if (req.body.PreviousStatusID == req.body.NextStatusID) {
     return res.status(422).send({
       message: 'Previous Status and Next Status should not be the same.',
       type: 'StatusError',
       data: {
-        previousStatus: prevStatus.StatusID,
-        nextStatus: nextStatus.StatusID
+        previousStatus: req.body.PreviousStatusID,
+        nextStatus: req.body.NextStatusID
       }
     })
   }
 
   const student = await students.getStudentById(req.body.StudentID)
 
-  if (student.StatusID !== prevStatus.StatusID) {
+  if (student.StatusID !== req.body.PreviousStatusID) {
     return res.status(409).send({
       message: 'Previous status must match current student status.',
       type: 'StatusMismatch',
       data: {
-        submittedStatus: prevStatus.StatusID,
+        submittedStatus: req.body.PreviousStatusID,
         actualStatus: student.StatusID
       }
     })

--- a/backend/src/routes/statusUpdates.js
+++ b/backend/src/routes/statusUpdates.js
@@ -2,6 +2,7 @@ const express = require('express')
 const router = express.Router()
 const statusUpdates = require('../helpers/statusUpdates')
 const statuses = require('../helpers/statuses')
+const students = require('../helpers/students')
 
 const { UniqueViolationError } = require('objection')
 
@@ -15,6 +16,30 @@ router.post('/', async (req, res) => {
   delete req.body.PrevStatusString
   delete req.body.NextStatusString
 
+  if (prevStatus.StatusID == nextStatus.StatusID) {
+    return res.status(422).send({
+      message: 'Previous Status and Next Status should not be the same.',
+      type: 'StatusError',
+      data: {
+        previousStatus: prevStatus.StatusID,
+        nextStatus: nextStatus.StatusID
+      }
+    })
+  }
+
+  const student = await students.getStudentById(req.body.StudentID)
+
+  if (student.StatusID !== prevStatus.StatusID) {
+    return res.status(409).send({
+      message: 'Previous status must match current student status.',
+      type: 'StatusMismatch',
+      data: {
+        submittedStatus: prevStatus.StatusID,
+        actualStatus: student.StatusID
+      }
+    })
+  }
+  
   const result = await statusUpdates.addStatusUpdate(req.body)
 
   // handle error


### PR DESCRIPTION
added validations for status updates - previous status cannot be the same as next status, and prev status should be the same as current status in database. Fixes #44 