### PR TITLE
Use root path for /new-student

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -36,7 +36,7 @@ export default {
   methods: {
     ...mapActions(["getAllStudents"]),
     createNew() {
-      this.$router.push({ path: "new-student" });
+      this.$router.push({ path: "/new-student" });
     },
   },
 };


### PR DESCRIPTION
Previously, clicking the `New +` button from the `/students/1` page would navigate to `/students/new-student`. This fixes the URL to navigate to `/new-student`.