### PR TITLE
Status Update Transaction

### DIFF
--- a/backend/src/helpers/statusUpdates.js
+++ b/backend/src/helpers/statusUpdates.js
@@ -1,8 +1,50 @@
 const db = require('../models/statusUpdate')
+const dbStudent = require('../models/student')
+const students = require('../helpers/students')
 
 exports.addStatusUpdate = async function (statusUpdate) {
   try {
-    const response = await db.StatusUpdate.query().insert(statusUpdate)
+    // Validate statusUpdate
+    if (statusUpdate.PreviousStatusID === statusUpdate.NextStatusID) {
+      throw Object.assign(
+        new Error('Previous status must not be the same as next status.'),
+        {
+          code: 409,
+          type: 'StatusMismatch',
+          data: {
+            previousStatus: statusUpdate.PreviousStatusID,
+            nextStatus: statusUpdate.NextStatusID
+          }
+        }
+      )
+    }
+
+    const student = await students.getStudentById(statusUpdate.StudentID)
+
+    if (student.StatusID !== statusUpdate.PreviousStatusID) {
+      throw Object.assign(
+        new Error('Previous status must match current student status.'),
+        {
+          code: 422,
+          type: 'StatusMismatch',
+          data: {
+            submittedStatus: statusUpdate.PreviousStatusID,
+            actualStatus: student.StatusID
+          }
+        }
+      )
+    }
+
+    // Execute transaction to update `statusUpdates` table and then update student status
+    const response = await db.StatusUpdate.transaction(async trx => {
+      await db.StatusUpdate.query().insert(statusUpdate)
+
+      // Then patch student status ('status')
+      const updateStudent = await dbStudent.Student.query(trx).findById(statusUpdate.StudentID).patch(
+        { StatusID: statusUpdate.NextStatusID }
+      )
+      return updateStudent
+    })
     return response
   } catch (err) {
     return { err }

--- a/backend/src/routes/screening.js
+++ b/backend/src/routes/screening.js
@@ -1,9 +1,10 @@
 const express = require('express')
 const router = express.Router()
 // const debug = require('debug')('app:students')
-const students = require("../helpers/students");
-const statuses = require("../helpers/statuses.js")
-const { NotFoundError } = require("objection");
+const students = require('../helpers/students')
+const statuses = require('../helpers/statuses.js')
+const statusUpdates = require('../helpers/statusUpdates.js')
+const { NotFoundError } = require('objection')
 
 // TODO: Handle errors
 
@@ -11,16 +12,30 @@ const { NotFoundError } = require("objection");
 // on Postman: http://localhost:3001/students/1
 router.post('/', async (req, res) => {
   if (Array.isArray(req.body)) {
-    // handle errors: Check if required fields are present
+    // TODO: handle errors: Check if required fields are present
 
-    // All students have Status set to UNMATCHED
-    const status = await statuses.getStatusByStatusString('UNMATCHED')
-    // process each item asynchronously
+    // All students have current status SCREENING and next status UNMATCHED
+    const currentStatus = await statuses.getStatusByStatusString('SCREENING')
+    const nextStatus = await statuses.getStatusByStatusString('UNMATCHED')
+
     const result = await Promise.all(req.body.map(async item => {
-      item.StatusID = status.StatusID
+      // Update status for each student asynchronously
+      // Construct statusUpdate
+      const statusUpdate = {
+        StudentID: item.StudentID,
+        PreviousStatusID: currentStatus.StatusID,
+        NextStatusID: nextStatus.StatusID,
+        UpdatedBy: item.UpdatedBy
+      }
+      // Delete `UpdatedBy` field from each item
+      delete item.UpdatedBy
+
+      statusUpdates.addStatusUpdate(statusUpdate)
+
+      // Update EnglishProficiency for each student asynchronously
       return students.patchStudent(item.StudentID, item)
-    }
-    ))
+    }))
+
     // Error handling
     if (result.err) {
       const err = result.err

--- a/backend/src/routes/screening.js
+++ b/backend/src/routes/screening.js
@@ -19,6 +19,13 @@ router.post('/', async (req, res) => {
     const nextStatus = await statuses.getStatusByStatusString('UNMATCHED')
 
     const result = await Promise.all(req.body.map(async item => {
+      // Check that item has UpdatedBy field
+      if (item.UpdatedBy == null) {
+        return res.status(400).send({
+          message: 'UpdatedBy field is required'
+        })
+      }
+
       // Update status for each student asynchronously
       // Construct statusUpdate
       const statusUpdate = {

--- a/backend/src/routes/statusUpdates.js
+++ b/backend/src/routes/statusUpdates.js
@@ -3,45 +3,36 @@ const router = express.Router()
 const reasons = require('../helpers/reasons')
 const statusUpdates = require('../helpers/statusUpdates')
 const statuses = require('../helpers/statuses')
-const students = require('../helpers/students')
 
 router.post('/', async (req, res) => {
   // If request does not contain PreviousStatusID and contains a PreviousStatusString
   if (req.body.PreviousStatusID == null && req.body.PreviousStatusString != null) {
-    const prevStatus = await statuses.getStatusByStatusString(req.body.PreviousStatusString)
-    req.body.PreviousStatusID = prevStatus.StatusID
-    delete req.body.PreviousStatusString
+    try {
+      const prevStatus = await statuses.getStatusByStatusString(req.body.PreviousStatusString)
+      req.body.PreviousStatusID = prevStatus.StatusID
+      delete req.body.PreviousStatusString
+    } catch (err) {
+      return res.status(500).send({
+        message: err.message,
+        type: 'UnknownError with Status',
+        data: {}
+      })
+    }
   }
 
   // If request does not contain NextStatusID and contains a NextStatusString
   if (req.body.NextStatusID == null && req.body.NextStatusString != null) {
-    const nextStatus = await statuses.getStatusByStatusString(req.body.NextStatusString)
-    req.body.NextStatusID = nextStatus.StatusID
-    delete req.body.NextStatusString
-  }
-
-  if (req.body.PreviousStatusID === req.body.NextStatusID) {
-    return res.status(422).send({
-      message: 'Previous Status and Next Status should not be the same.',
-      type: 'StatusError',
-      data: {
-        previousStatus: req.body.PreviousStatusID,
-        nextStatus: req.body.NextStatusID
-      }
-    })
-  }
-
-  const student = await students.getStudentById(req.body.StudentID)
-
-  if (student.StatusID !== req.body.PreviousStatusID) {
-    return res.status(409).send({
-      message: 'Previous status must match current student status.',
-      type: 'StatusMismatch',
-      data: {
-        submittedStatus: req.body.PreviousStatusID,
-        actualStatus: student.StatusID
-      }
-    })
+    try {
+      const nextStatus = await statuses.getStatusByStatusString(req.body.NextStatusString)
+      req.body.NextStatusID = nextStatus.StatusID
+      delete req.body.NextStatusString
+    } catch (err) {
+      return res.status(500).send({
+        message: err.message,
+        type: 'UnknownError with Status',
+        data: {}
+      })
+    }
   }
 
   // If request does not contain ReasonID
@@ -66,12 +57,11 @@ router.post('/', async (req, res) => {
   // handle error
   if (result.err) {
     const err = result.err
-    res.status(500).send({
+    res.status(err.code).send({
       message: err.message,
-      type: 'UnknownError',
-      data: {}
+      type: err.type,
+      data: err.data
     })
-
     return
   }
 

--- a/frontend/src/pages/Screening.vue
+++ b/frontend/src/pages/Screening.vue
@@ -174,7 +174,9 @@ export default {
           const patchStudentsData = this.checkedRows.map(item => {
             return {
               StudentID: item.StudentID,
-              EnglishProficiency: item.EnglishProficiency
+              EnglishProficiency: item.EnglishProficiency,
+              // TODO: Make dynamic with account management
+              UpdatedBy: "IRRCAdmin"
             }
           })
           this.patchScreeningStudents(patchStudentsData)

--- a/frontend/src/store/students.js
+++ b/frontend/src/store/students.js
@@ -28,17 +28,8 @@ export const studentActions = {
 
     // Update student status
     async updateStudentStatus({ commit, dispatch }, { studentID, previousStatusString, nextStatusString, updatedBy, reason }) {
-        // PATCH student
-        const studentRequestOptions = {
-            method: "PATCH",
-            headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({StudentID: studentID, StatusString: nextStatusString})
-        }
-
-        // POST statusUpdate
+        // POST statusUpdate. Note that the POST statusUpdate endpoint also patches the student status
+        // behind-the-scenes.
         const statusUpdateRequestOptions = {
             method: "POST",
             headers: {
@@ -59,14 +50,6 @@ export const studentActions = {
             if(response.status !== 200) {
                 throw new Error(response);
             }
-        })
-        .then(() => {
-            fetch("/api/students/" + studentID, studentRequestOptions)
-            .then((response) => {
-            if(response.status !== 200) {
-                throw new Error(response);
-            }
-            })
         })
         .then(() => {
             dispatch('getAllStudents')


### PR DESCRIPTION
Addresses #77 

Changes to student status should not be made through the students endpoint. Rather they should be made through the status updates endpoint, making sure to provide the `UpdatedBy` field
Any insertion to the status updates table should be made with a corresponding update to the student status in the students table (i.e. the 2 operations are a single transaction)