### PR TITLE
Create and save student with null English Proficiency

### DIFF
--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -62,7 +62,7 @@ router.get('/:id', async (req, res) => {
 /* POST students listing */
 router.post('/', async (req, res) => {
   // If EnglishProficiency is empty
-  if (req.body.EnglishProficiency === "" || null) {
+  if (!req.body.EnglishProficiency || req.body.EnglishProficiency === "") {
     delete req.body.EnglishProficiency
   }
   // If request does not contain StatusID

--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -61,6 +61,10 @@ router.get('/:id', async (req, res) => {
 
 /* POST students listing */
 router.post('/', async (req, res) => {
+  // If EnglishProficiency is empty
+  if (req.body.EnglishProficiency === "" || null) {
+    delete req.body.EnglishProficiency
+  }
   // If request does not contain StatusID
   if (req.body.StatusID == null) {
     let statusString
@@ -142,7 +146,10 @@ router.patch('/:id', async (req, res) => {
       })
     }
   }
-
+  // If EnglishProficiency is empty, delete it from the request body
+  if (!req.body.EnglishProficiency || req.body.EnglishProficiency === "") {
+    delete req.body.EnglishProficiency
+  }
   // If request does not contain StatusID and contains a StatusString
   if (req.body.StatusID == null && req.body.StatusString != null) {
     const statusString = req.body.StatusString


### PR DESCRIPTION
Fixes #84 by deleting EnglishProficiency from the request body to POST/PATCH whenever EnglishProficiency is "" or null. 

We couldn't post students with no EngProf from the frontend as an empty EngProf would be sent to the backend as EnglishProficiency: "" instead of not being sent at all. Then it'd fail as it violates the constraints for EngProf (as "" is not one of the enum values). 