### PR TITLE
Issue #86: Status card updates after changing status 

### DIFF
--- a/frontend/src/components/modals/ModalDroppedOut.vue
+++ b/frontend/src/components/modals/ModalDroppedOut.vue
@@ -115,3 +115,11 @@ export default {
     }
 }
 </script>
+<style>
+.modal-card-body{
+    width: 640px
+}
+.modal-card-foot{
+    width: 640px
+}
+</style>

--- a/frontend/src/components/modals/ModalDroppedOut.vue
+++ b/frontend/src/components/modals/ModalDroppedOut.vue
@@ -100,9 +100,8 @@ export default {
           nextStatusString: nextStatusString,
           updatedBy: updatedBy,
           reason: "DROPPED_" + this.reason,
-        }).then(() => {
-          +this.$emit("close");
         });
+        this.$emit("close")
       } else {
         this.updateStudentStatus({
           studentID: studentID,
@@ -128,15 +127,6 @@ export default {
         onConfirm: async (value) => {
           this.selected.Reason = value;
           this.addDroppedReason(this.selected.Reason);
-          // // TODO: notification on successful dispatch
-          // .then(() => {
-          //     this.$buefy.notification.open({
-          //         message: 'New reason added.',
-          //         duration: 3000,
-          //         type: 'is-success',
-          //         position: 'is-top',
-          //     })
-          // })
         },
       });
     },
@@ -145,9 +135,9 @@ export default {
 </script>
 <style>
 .modal-card-body{
-    width: 640px
+    width: auto
 }
 .modal-card-foot{
-    width: 640px
+    width: auto
 }
 </style>

--- a/frontend/src/components/statusCards/StatusCardDroppedOut.vue
+++ b/frontend/src/components/statusCards/StatusCardDroppedOut.vue
@@ -43,7 +43,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions([ 'updateStudentStatus' ]),
+    ...mapActions([ 'updateStudentStatus']),
     droppedOutToScreening() {
       const studentID = parseInt(this.studentID)
       const previousStatusString = "DROPPED OUT"

--- a/frontend/src/pages/StudentProfile.vue
+++ b/frontend/src/pages/StudentProfile.vue
@@ -13,15 +13,15 @@
             status: studentData.status.Description,
             proficiencyLevel: studentData.EnglishProficiency,
           }"
-          v-on:englishProficiencyIsSelected="englishProficiency = $event"
+          v-on:englishProficiencyIsSelected="studentData.EnglishProficiency = $event"
         />
       </div>
       <div class="student-profile-right">
         <section class="student-status-section">
-          <StatusCardScreening :studentID="studentID" :englishProficiency="englishProficiency" v-if="studentData.status.Description.toUpperCase() === 'SCREENING'" />
-          <StatusCardUnmatched :studentID="studentID" v-if="studentData.status.Description.toUpperCase() === 'UNMATCHED'" />
-          <StatusCardMatched :studentID="studentID" v-if="studentData.status.Description.toUpperCase() === 'MATCHED'" />
-          <StatusCardDroppedOut :studentID="studentID" :latestReason="latestReason" v-if="studentData.status.Description.toUpperCase() === 'DROPPED OUT'" />
+          <StatusCardScreening :studentID="studentData.StudentID" :englishProficiency="studentData.EnglishProficiency" v-if="studentData.status.Description.toUpperCase() === 'SCREENING'" />
+          <StatusCardUnmatched :studentID="studentData.StudentID" v-if="studentData.status.Description.toUpperCase() === 'UNMATCHED'" />
+          <StatusCardMatched :studentID="studentData.StudentID" v-if="studentData.status.Description.toUpperCase() === 'MATCHED'" />
+          <StatusCardDroppedOut :studentID="studentData.StudentID" :latestReason="latestReason" v-if="studentData.status.Description.toUpperCase() === 'DROPPED OUT'" />
         </section>
         <section class="student-history-section">
           <StudentHistory v-bind:items="studentHistory" />
@@ -52,56 +52,30 @@ export default {
     StatusCardScreening,
     StatusCardUnmatched,
   },
-  data: function() {
-    return {
-      englishProficiency: "",
-      studentData: {
-        StudentID: -1,
-        PhoneNumber: "",
-        FullName: "",
-        Source: "",
-        nativeLanguage: {
-          NativeLanguageID: -1,
-          NativeLanguage: "",
-        },
-        EnglishProficiency: "",
-        Notes: "",
-        status: {
-          StatusID: -1,
-          Description: "",
-        },
-      },
-      studentHistory: [],
-      studentID: this.$route.params.id,
-      latestReason: ""
-    };
-  },
   computed: {
-    ...mapGetters([ 'getStudentByStudentId' ])
-  },
-  mounted: function() {
-    const id = this.$route.params.id
-    const data = this.getStudentByStudentId(id)
-
-    const studentObject = {
-          StudentID: data.StudentID,
-          PhoneNumber: data.PhoneNumber,
-          FullName: data.FullName,
-          Source: data.Source,
-          nativeLanguage: data.nativeLanguage,
-          status: data.status,
-          Notes: data.Notes,
-          dateJoined: new Date(data.created_at).toDateString(),
-          EnglishProficiency: data.EnglishProficiency,
-        };
-
-    const studentHistory = data.statusUpdates.map(update => {
+    ...mapGetters([ 'getStudentByStudentId' ]),
+    studentData(){
+      const data = this.student
+      const studentObject = {
+            StudentID: data.StudentID.toString(),
+            PhoneNumber: data.PhoneNumber,
+            FullName: data.FullName,
+            Source: data.Source,
+            nativeLanguage: data.nativeLanguage,
+            status: data.status,
+            Notes: data.Notes,
+            dateJoined: new Date(data.created_at).toDateString(),
+            EnglishProficiency: data.EnglishProficiency,
+          };
+      return studentObject
+    },
+    studentHistory(){
+    const studentHistory = this.student.statusUpdates.map(update => {
       if (update.reason == null) {
         update.reason = {
           Reason: "_"
         }
-      }
-      
+      } 
       return {
         id: update.StatusUpdateID,
         date: new Date(update.created_at).toDateString(),
@@ -110,15 +84,18 @@ export default {
         reason: update.reason.Reason.split('_')[1]
       };
     });
+    return studentHistory.sort((a, b) => b.id - a.id)
+    },
+    latestReason(){
+        return this.studentHistory[0].reason
 
-    this.studentData = studentObject;
-    this.studentHistory = studentHistory;
-
-    var latestStatusUpdateID = Math.max.apply(Math, studentHistory.map(function(o){return o.id;}))
-    if (latestStatusUpdateID !== null && latestStatusUpdateID !== -Infinity) {
-      this.latestReason = studentHistory.find(function(o){ return o.id == latestStatusUpdateID; }).reason
+    },
+    student(){
+      const id = this.$route.params.id
+      const data = this.getStudentByStudentId(id)
+      return data 
     }
-  },
+  }
 };
 </script>
 

--- a/frontend/src/store/reasons.js
+++ b/frontend/src/store/reasons.js
@@ -47,6 +47,7 @@ export const reasonActions = {
               return;
             }
             dispatch('getDroppedReasons')
+            dispatch('getAllStudents')
           }
         )
     },

--- a/frontend/src/store/students.js
+++ b/frontend/src/store/students.js
@@ -27,7 +27,7 @@ export const studentActions = {
     },
 
     // Update student status
-    async updateStudentStatus({ commit, dispatch }, { studentID, previousStatusString, nextStatusString, updatedBy, reason }) {
+    updateStudentStatus({ commit, dispatch }, { studentID, previousStatusString, nextStatusString, updatedBy, reason }) {
         // POST statusUpdate. Note that the POST statusUpdate endpoint also patches the student status
         // behind-the-scenes.
         const statusUpdateRequestOptions = {
@@ -50,10 +50,9 @@ export const studentActions = {
             if(response.status !== 200) {
                 throw new Error(response);
             }
-        })
-        .then(() => {
             dispatch('getAllStudents')
         })
+       
         .catch((err) => {
             console.error(err);
         });


### PR DESCRIPTION
Fixes #86 by using computed properties — data is now reactive, and cards will change after status is changed (e.g. clicking Drop Out + confirm will change the status card to Dropped Out, clicking "reactivate for Screening" will change the card to Screening) 