### PR TITLE
Update syntax in vite.config.js

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,6 @@
-import { createVuePlugin } from 'vite-plugin-vue2'
+const { createVuePlugin } = require('vite-plugin-vue2')
 
-export default {
+module.exports = {
   alias: {
     'vue': 'vue/dist/vue.esm.js'
   },


### PR DESCRIPTION
This follows the syntax in the `vite-plugin-vue2` project README. I had to do a fresh install of `npm` which raised transpile errors when using the previous syntax. This new syntax just works. 

Does this work for others?