### PR TITLE
Link up 'Edit' button in individual Profiles

### DIFF
--- a/frontend/src/components/ProfileCard.vue
+++ b/frontend/src/components/ProfileCard.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="card">
-    <div class="edit-container">Edit</div>
+    <div class="edit-container">
+      <router-link v-if="isTeacher" :to="'/edit-teacher/' + profile.id">Edit</router-link>
+      <router-link v-else :to="'/edit-student/' + profile.id">Edit</router-link>
+    </div>
     <div class="profile-grid">
       <img v-if="isTeacher" src="../assets/teacher.png" />
       <img v-else src="../assets/images/student.png" />
@@ -81,6 +84,7 @@ export default {
       type: Object,
       default: function () {
         return {
+          id: "0",
           name: "Default Name",
           contact: "9123 4567",
           dateJoined: "Sept 07 2020",

--- a/frontend/src/pages/EditStudent.vue
+++ b/frontend/src/pages/EditStudent.vue
@@ -127,8 +127,8 @@ export default {
     },
     updateStudentSuccess(value){
       if(value === true){
-        this.$buefy.notification.open({
-              message: 'Student saved. <u>View profile</u>!',
+        this.$buefy.toast.open({
+              message: `Student saved. <u><a href="/students/${this.studentData.StudentID}">View profile</a></u>!`,
               duration: 3000,
               type: 'is-success',
               position: 'is-top',

--- a/frontend/src/pages/EditTeacher.vue
+++ b/frontend/src/pages/EditTeacher.vue
@@ -210,7 +210,7 @@ export default {
           // refreshes state
           this.getNativeLanguages();
           setTimeout(() => {
-            this.$router.push({ path: `/teachers` });
+            this.$router.push({ path: `/teachers/${this.teacherData.TeacherID}` });
           }, 2000);
       }
       else if (value === false) {

--- a/frontend/src/pages/EditTeacher.vue
+++ b/frontend/src/pages/EditTeacher.vue
@@ -201,8 +201,8 @@ export default {
     },
     updateTeacherSuccess(value) {
       if(value === true){
-        this.$buefy.notification.open({
-            message: "Teacher Data Updated. <u>View profile</u>!",
+        this.$buefy.toast.open({
+            message: `Teacher saved. <u><a href="/teachers/${this.teacherData.TeacherID}">View profile</a></u>!`,
             duration: 3000,
             type: "is-success",
             position: "is-top",

--- a/frontend/src/pages/StudentProfile.vue
+++ b/frontend/src/pages/StudentProfile.vue
@@ -4,6 +4,7 @@
       <div class="student-profile-left">
         <ProfileCard
           v-bind:profile="{
+            id: studentData.StudentID,
             name: studentData.FullName,
             contact: studentData.PhoneNumber,
             source: studentData.Source,

--- a/frontend/src/pages/TeacherProfile.vue
+++ b/frontend/src/pages/TeacherProfile.vue
@@ -4,6 +4,7 @@
       <div class="teacher-profile-left">
         <ProfileCard
           v-bind:profile="{
+            id: teacherData.TeacherID,
             name: teacherData.FullName,
             contact: teacherData.PhoneNumber,
             source: teacherData.Source,


### PR DESCRIPTION
This is a small diff, but it is based on #109 (which made it a lot less confusing to implement).

Changes:
- from the individual Student (Teacher) Profile, the 'Edit' text now links to the relevant `/edit-student/StudentID` (`/edit-teacher/TeacherID`)
- after changes are saved on the Edit Student (Teacher) page, the "View Profile" text in the popup now links to the appropriate Student (Teacher) Profile.