### PR TITLE
Clickthrough from Students / Teachers / Screening tables to Profiles

### DIFF
--- a/frontend/src/pages/Screening.vue
+++ b/frontend/src/pages/Screening.vue
@@ -37,6 +37,8 @@
           checkable
           :checkbox-position="checkboxPosition"
           :is-row-checkable="(row) => row.EnglishProficiency !== null"
+          :selected.sync="selected"
+          @dblclick="goToStudent"
         >
           <!-- Student ID column -->
 
@@ -106,7 +108,7 @@ import { mapGetters, mapActions, mapState } from "vuex";
 export default {
   data() {
     return {
-      selected: null,
+      selected: {},
       sortIcon: "arrow-up",
       sortIconSize: "is-small",
       sortDirection: "asc",
@@ -182,6 +184,9 @@ export default {
           this.patchScreeningStudents(patchStudentsData)
         }
       }) 
+    },
+    goToStudent() {
+      this.$router.push({ path: `/students/${this.selected.StudentID}` })
     }
   }
 };

--- a/frontend/src/pages/Students.vue
+++ b/frontend/src/pages/Students.vue
@@ -2,7 +2,7 @@
   <Page>
     <div class="container">
       <div class="Title">
-        <b class="newStudent">All Students</b>
+        <b>All Students</b>
       </div>
       <!--start of table -->
       <section>
@@ -11,6 +11,8 @@
           :sort-icon="sortIcon"
           :sort-icon-size="sortIconSize"
           :sortDirection="sortDirection"
+          :selected.sync="selected"
+          @dblclick="goToStudent"
         >
           <!-- date column -->
 
@@ -176,7 +178,7 @@ import { mapActions } from "vuex";
 export default {
   data() {
     return {
-      selected: null,
+      selected: {},
       sortIcon: "arrow-up",
       sortIconSize: "is-small",
       sortDirection: "asc",
@@ -229,6 +231,9 @@ export default {
   },
   methods: {
     ...mapActions(["getAllStudents"]),
+    goToStudent() {
+      this.$router.push({ path: `/students/${this.selected.StudentID}` })
+    }
   },
   mounted() {
     this.getAllStudents();

--- a/frontend/src/pages/Teachers.vue
+++ b/frontend/src/pages/Teachers.vue
@@ -7,7 +7,10 @@
         
         <section>
             <b-table
-            :data="teachersData">
+            :data="teachersData"
+            :selected.sync="selected"
+            @dblclick="goToTeacher"
+            >
                 <b-table-column field="created_at" label="Date Joined" width="120" searchable sortable>
                      <template
                     slot="searchable"
@@ -139,9 +142,16 @@ export default {
         },
         ...mapGetters(['teachers'])
     },
+    data() {
+        return {
+          selected: {},
+        }
+    },
     methods: {
-        ...mapActions(['getAllTeachers'])
-
+        ...mapActions(['getAllTeachers']),
+        goToTeacher() {
+          this.$router.push({ path: `/teachers/${this.selected.TeacherID}` })
+        }
     },
     mounted() {
         this.getAllTeachers()


### PR DESCRIPTION
On double-clicking a row in the Students (Teachers) table, the user is redirected to the individual Student (Teacher) Profile.

On double-clicking a row in the Screening table, the user is also redirected to the individual Student Profile.