### PR TITLE
IRRC-37/unmatch student flow

### DIFF
--- a/backend/src/routes/matches.js
+++ b/backend/src/routes/matches.js
@@ -78,6 +78,7 @@ const deleteMatches = async ({field, id, nextStatusString, res})=>{
         await statusUpdates.addStatusUpdate(statusUpdate)
       }))
     }
+    // Delete match
     await db.Match.query()
       .delete()
       .where(field, id)

--- a/backend/src/routes/matches.js
+++ b/backend/src/routes/matches.js
@@ -1,105 +1,131 @@
-const express = require('express')
-const router = express.Router()
-const db = require('../models/index')
-const statuses = require('../helpers/statuses')
-const statusUpdates = require('../helpers/statusUpdates.js')
-
+const express = require("express");
+const router = express.Router();
+const db = require("../models/index");
+const statuses = require("../helpers/statuses");
+const statusUpdates = require("../helpers/statusUpdates.js");
 
 /* GET matches listing. */
-router.get('/', async (req, res) => {
-    const matches = await db.Match.query().select('MatchID', 'StudentID', 'TeacherID', 'StudentStatusUpdateID', 'TeacherStatusUpdateID', 'LastEmailDate', 'MatchStatus', 'ConfirmedDate')
-    res.json(matches)
-  })
+router.get("/", async (req, res) => {
+  const matches = await db.Match.query().select(
+    "MatchID",
+    "StudentID",
+    "TeacherID",
+    "StudentStatusUpdateID",
+    "TeacherStatusUpdateID",
+    "LastEmailDate",
+    "MatchStatus",
+    "ConfirmedDate"
+  );
+  res.json(matches);
+});
 
 /* POST Delete matches from teacher profile */
-const deleteMatches = async ({field, id, nextStatusString, res})=>{ 
-// ERROR HANDLING
-    // nextStatusString must be UNMATCHED/DROPPED OUT, or else request will not be accepted.
-    const statusDeleteMatch = ["UNMATCHED", "DROPPED OUT"]
-    if (!statusDeleteMatch.includes(nextStatusString)){
-      return res.status(200).send({
-        message: `${nextStatusString} must be "UNMATCHED" or "DROPPED OUT"`,
-      })
+const deleteMatches = async ({ field, id, nextStatusString, res }) => {
+  // ERROR HANDLING
+  // nextStatusString must be UNMATCHED/DROPPED OUT, or else request will not be accepted.
+  const statusDeleteMatch = ["UNMATCHED", "DROPPED OUT"];
+  if (!statusDeleteMatch.includes(nextStatusString)) {
+    return res.status(200).send({
+      message: `${nextStatusString} must be "UNMATCHED" or "DROPPED OUT"`,
+    });
+  }
+  // Check if id or nextStatusString are null/undefined/empty
+  if (id == null || id == undefined) {
+    return res.status(500).send({
+      message: `${field} is undefined or null`,
+      type: "UnknownError",
+    });
+  }
+  if (
+    nextStatusString == "" ||
+    nextStatusString == null ||
+    nextStatusString == undefined
+  ) {
+    // console.log(nextStatusString)
+    return res.status(500).send({
+      message: `nextStatusString is empty, undefined or null.`,
+      type: "UnknownError",
+    });
+  }
+  // Asynchronously get current status in any order - used for both TeacherID and StudentID scenarios
+  const [currentStatus, nextStatus] = await Promise.all([
+    statuses.getStatusByStatusString("MATCHED"),
+    statuses.getStatusByStatusString("UNMATCHED"),
+  ]);
+  if (field === "StudentID") {
+    // select(1) returns an object instead of an array. Only one result is expected as one student has one teacher
+    // Note: teacherMatched returns an array
+    const teacherMatched = await db.Match.query()
+      .select("TeacherID")
+      .where(field, id);
+    const teacherMatchedID = teacherMatched[0].TeacherID;
+    console.log(teacherMatched[0]);
+    // Count number of students the teacher has
+    const studentsCount = await db.Match.query()
+      .select("StudentID")
+      .where("TeacherID", teacherMatchedID);
+
+    // Change teacher's status only if this student is their only student.
+    if (studentsCount.length == 1) {
+      const teacherStatusUpdate = {
+        TeacherID: teacherMatchedID,
+        PreviousStatusID: currentStatus.StatusID,
+        NextStatusID: nextStatus.StatusID,
+        UpdatedBy: "IRRCAdmin",
+      };
+      await statusUpdates.addStatusUpdate(teacherStatusUpdate);
     }
-    // Check if id or nextStatusString are null/undefined/empty
-    if (id == null || id == undefined) {
-      return res.status(500).send({
-        message: `${field} is undefined or null`,
-        type: 'UnknownError'
-      })
-    }
-    if (nextStatusString == "" || nextStatusString == null || nextStatusString == undefined) {
-      // console.log(nextStatusString)
-      return res.status(500).send({
-        message: `nextStatusString is empty, undefined or null.`,
-        type: 'UnknownError'
-      })
-    }
-    // Asynchronously get current status in any order - used for both TeacherID and StudentID scenarios
-    const [currentStatus, nextStatus] = await Promise.all([
-      statuses.getStatusByStatusString('MATCHED'),
-      statuses.getStatusByStatusString('UNMATCHED')
-    ])
-    if (field === "StudentID") {
-      // select(1) returns an object instead of an array. Only one result is expected as one student has one teacher
-      // Note: teacherMatched returns an array
-      const teacherMatched = await db.Match.query().select("TeacherID").where(field, id)
-      const teacherMatchedID = teacherMatched[0].TeacherID
-      console.log(teacherMatched[0])
-      // Count number of students the teacher has 
-      const studentsCount = await db.Match.query().select("StudentID").where("TeacherID", teacherMatchedID)
-      
-      // Change teacher's status only if this student is their only student. 
-      if (studentsCount.length == 1){
-        const teacherStatusUpdate = {
-          TeacherID: teacherMatchedID,
-          PreviousStatusID: currentStatus.StatusID,
-          NextStatusID: nextStatus.StatusID,
-          UpdatedBy: "IRRCAdmin"
-        }
-        await statusUpdates.addStatusUpdate(teacherStatusUpdate)
-      }
-    } 
-    /* Check if field is TeacherID */ 
-    if (field === "TeacherID") {
-      // Query for studentIDs linked to the TeacherID
-      const studentsMatched = await db.Match.query().select("StudentID").where(field, id)
-      // Update status of all students linked to the TeacherID 
-      
-      // TODO: Implement status updates for students as a transaction to avoid cases where status is changed only for some 
-      await Promise.all(studentsMatched.map(async student => {
+  }
+  /* Check if field is TeacherID */
+  if (field === "TeacherID") {
+    // Query for studentIDs linked to the TeacherID
+    const studentsMatched = await db.Match.query()
+      .select("StudentID")
+      .where(field, id);
+    // Update status of all students linked to the TeacherID
+
+    // TODO: Implement status updates for students as a transaction to avoid cases where status is changed only for some
+    await Promise.all(
+      studentsMatched.map(async (student) => {
         // Construct statusUpdate
         const statusUpdate = {
           StudentID: student.StudentID,
           PreviousStatusID: currentStatus.StatusID,
           NextStatusID: nextStatus.StatusID,
-          UpdatedBy: "IRRCAdmin"
-        }
-        await statusUpdates.addStatusUpdate(statusUpdate)
-      }))
-    }
-    // Delete match
-    await db.Match.query()
-      .delete()
-      .where(field, id)
-}
-// Req body should include TeacherID 
-router.post('/teacher', async (req, res) => {
-    const body = req.body 
-    // Change all students' statuses for a given teacher
-    await deleteMatches({field: "TeacherID", id: body.TeacherID, nextStatusString: body.NextStatusString, res})
-    return res.json(200, "successful")
-
-    })
+          UpdatedBy: "IRRCAdmin",
+        };
+        await statusUpdates.addStatusUpdate(statusUpdate);
+      })
+    );
+  }
+  // Delete match
+  await db.Match.query().delete().where(field, id);
+};
+// Req body should include TeacherID
+router.post("/unmatch-teacher", async (req, res) => {
+  const body = req.body;
+  // Change all students' statuses for a given teacher
+  await deleteMatches({
+    field: "TeacherID",
+    id: body.TeacherID,
+    nextStatusString: body.NextStatusString,
+    res,
+  });
+  return res.json(200, "successful");
+});
 
 // Delete student-teacher (1:1) match when you cilck Unmatch/Dropped Out from a student profile
-router.post('/student', async (req, res) => {
+router.post("/unmatch-student", async (req, res) => {
   // Check if student:teacher is 1:1. if teacher only has one student, then the teacher's status must also be changed.
   // If a student is not the teacher's only student, the teacher's status will not change.
-  const body = req.body 
-  await deleteMatches({field: "StudentID", id: body.StudentID, nextStatusString: body.NextStatusString, res})
-  return res.json(200, "successful")
+  const body = req.body;
+  await deleteMatches({
+    field: "StudentID",
+    id: body.StudentID,
+    nextStatusString: body.NextStatusString,
+    res,
+  });
+  return res.json(200, "successful");
+});
 
-})
-
-module.exports = router
+module.exports = router;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1446,7 +1446,6 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1510,7 +1509,6 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -1522,8 +1520,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -1531,8 +1528,7 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1887,8 +1883,7 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.0",
@@ -2147,8 +2142,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -4024,8 +4018,7 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/frontend/src/store/students.js
+++ b/frontend/src/store/students.js
@@ -1,140 +1,145 @@
 const MUTATIONS = Object.freeze({
-    SET_STUDENTS: 'SET_STUDENTS',
-    SET_UPDATE_STUDENT_SUCCESS: 'SET_UPDATE_STUDENT_SUCCESS'
-  })
+  SET_STUDENTS: "SET_STUDENTS",
+  SET_UPDATE_STUDENT_SUCCESS: "SET_UPDATE_STUDENT_SUCCESS",
+});
 
-
-export const studentState = {students: [], updateStudentSuccess: undefined} 
+export const studentState = { students: [], updateStudentSuccess: undefined };
 export const studentActions = {
-    async getAllStudents({commit}){
-        const response = await fetch("/api/students")
-        const studentData = await response.json()
-        commit(MUTATIONS.SET_STUDENTS, studentData)        
-    },
+  async getAllStudents({ commit }) {
+    const response = await fetch("/api/students");
+    const studentData = await response.json();
+    commit(MUTATIONS.SET_STUDENTS, studentData);
+  },
 
-    async createStudent({dispatch}, studentData){
-        const payload = {
-        method: "POST",
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(studentData)
-        }
-        const response = await fetch("/api/students", payload)
-        dispatch("getAllStudents")
-        return response     
-    },
+  async createStudent({ dispatch }, studentData) {
+    const payload = {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(studentData),
+    };
+    const response = await fetch("/api/students", payload);
+    dispatch("getAllStudents");
+    return response;
+  },
 
-    // PATCH Student Data to backend 
-    async patchStudent({dispatch, commit}, studentData){
-        const patchStudent = {
-            method: "PATCH",
-            headers: {
-              'Accept': 'application/json',
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(
-              studentData 
-            )
-          }
-        const response = await fetch(`/api/students/${studentData.StudentID}`, patchStudent)
-        if(response.status === 200){
-            dispatch("getAllStudents")
-            commit('SET_UPDATE_STUDENT_SUCCESS', true)
+  // PATCH Student Data to backend
+  async patchStudent({ dispatch, commit }, studentData) {
+    const patchStudent = {
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(studentData),
+    };
+    const response = await fetch(
+      `/api/students/${studentData.StudentID}`,
+      patchStudent
+    );
+    if (response.status === 200) {
+      dispatch("getAllStudents");
+      commit("SET_UPDATE_STUDENT_SUCCESS", true);
+    } else {
+      commit("SET_UPDATE_STUDENT_SUCCESS", false);
+    }
+  },
+  resetUpdateStudentSuccess({ commit }, value) {
+    commit(MUTATIONS.SET_UPDATE_STUDENT_SUCCESS, value);
+  },
+  // Update student status
+  updateStudentStatus(
+    { commit, dispatch },
+    { studentID, previousStatusString, nextStatusString, updatedBy, reason }
+  ) {
+    // POST statusUpdate. Note that the POST statusUpdate endpoint also patches the student status
+    // behind-the-scenes.
+    const statusUpdateRequestOptions = {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        StudentID: studentID,
+        PreviousStatusString: previousStatusString,
+        NextStatusString: nextStatusString,
+        UpdatedBy: updatedBy,
+        ReasonString: reason,
+      }),
+    };
+
+    fetch("/api/statusUpdates", statusUpdateRequestOptions)
+      .then((response) => {
+        if (response.status !== 200) {
+          throw new Error(response);
         }
-        else{
-            commit('SET_UPDATE_STUDENT_SUCCESS', false)
-        }
-    },
-    resetUpdateStudentSuccess({commit}, value){
-        commit(MUTATIONS.SET_UPDATE_STUDENT_SUCCESS, value)
-    },
-    // Update student status
-    updateStudentStatus({ commit, dispatch }, { studentID, previousStatusString, nextStatusString, updatedBy, reason }) {
-        // POST statusUpdate. Note that the POST statusUpdate endpoint also patches the student status
-        // behind-the-scenes.
-        const statusUpdateRequestOptions = {
-            method: "POST",
-            headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
+        dispatch("getAllStudents");
+
+        // Calls deletion API to delete matches if moving from MATCHED -> UNMATCHED/DROPPED OUT
+        fetch("/api/matches/unmatch-student", {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
             StudentID: studentID,
-            PreviousStatusString: previousStatusString,
             NextStatusString: nextStatusString,
-            UpdatedBy: updatedBy,
-            ReasonString: reason
-            })
-        }
-
-        fetch("/api/statusUpdates", statusUpdateRequestOptions)
-        .then((response) => {
-            if(response.status !== 200) {
-                throw new Error(response);
-            }
-            dispatch('getAllStudents')
-
-            // Calls deletion API to delete matches if moving from MATCHED -> UNMATCHED/DROPPED OUT
-            fetch('/api/matches/student', {
-                method: "POST",
-                headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                StudentID: studentID,
-                NextStatusString: nextStatusString,
-                })
-            })
-            // TODO: Call matches API after this to refresh
-            // fetch('api/matches').then(response => response.json) ? 
-        })
-       
-        .catch((err) => {
-            console.error(err);
+          }),
         });
-    },
+        // TODO: Call matches API after this to refresh
+        // fetch('api/matches').then(response => response.json) ?
+      })
 
-    // Update student English proficiency
-    async updateStudentEnglishProficiency({ commit, dispatch }, { studentID, englishProficiency }) {
+      .catch((err) => {
+        console.error(err);
+      });
+  },
 
+  // Update student English proficiency
+  async updateStudentEnglishProficiency(
+    { commit, dispatch },
+    { studentID, englishProficiency }
+  ) {
     if (!englishProficiency) return;
 
     // PATCH student
     const studentRequestOptions = {
-        method: "PATCH",
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({StudentID: studentID, EnglishProficiency: englishProficiency})
-    }
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        StudentID: studentID,
+        EnglishProficiency: englishProficiency,
+      }),
+    };
 
-    fetch("/api/students/" + studentID, studentRequestOptions)
-        .then(response => {
-            // If PATCH fails, return
-            if(response.status !== 200) {
-            console.log(response);
-            return;
-            }
-            dispatch('getAllStudents')
+    fetch("/api/students/" + studentID, studentRequestOptions).then(
+      (response) => {
+        // If PATCH fails, return
+        if (response.status !== 200) {
+          console.log(response);
+          return;
         }
-        )
-    },
-}
+        dispatch("getAllStudents");
+      }
+    );
+  },
+};
 export const studentMutations = {
-    [MUTATIONS.SET_STUDENTS](state, students){
-        state.students = students
-    },
-    [MUTATIONS.SET_UPDATE_STUDENT_SUCCESS](state, value){
-        // sets updateStudentSuccess to true
-        state.updateStudentSuccess = value
-    }
-} 
+  [MUTATIONS.SET_STUDENTS](state, students) {
+    state.students = students;
+  },
+  [MUTATIONS.SET_UPDATE_STUDENT_SUCCESS](state, value) {
+    // sets updateStudentSuccess to true
+    state.updateStudentSuccess = value;
+  },
+};
 export const studentGetters = {
-    students: (state) => state.students
-
-} 
-
+  students: (state) => state.students,
+};

--- a/frontend/src/store/students.js
+++ b/frontend/src/store/students.js
@@ -75,7 +75,8 @@ export const studentActions = {
                 throw new Error(response);
             }
             dispatch('getAllStudents')
-            // Call deletion API to delete matches if moving from MATCHED -> UNMATCHED/DROPPED OUT
+
+            // Calls deletion API to delete matches if moving from MATCHED -> UNMATCHED/DROPPED OUT
             fetch('/api/matches/student', {
                 method: "POST",
                 headers: {
@@ -88,6 +89,7 @@ export const studentActions = {
                 })
             })
             // TODO: Call matches API after this to refresh
+            // fetch('api/matches').then(response => response.json) ? 
         })
        
         .catch((err) => {

--- a/frontend/src/store/teachers.js
+++ b/frontend/src/store/teachers.js
@@ -2,7 +2,7 @@ import Vuex from "vuex";
 
 const MUTATIONS = Object.freeze({
   SET_TEACHERS: "SET_TEACHERS",
-  SET_UPDATE_TEACHER_SUCCESS: "SET_UPDATE_TEACHER_SUCCESS"
+  SET_UPDATE_TEACHER_SUCCESS: "SET_UPDATE_TEACHER_SUCCESS",
 });
 export const teacherState = { teachers: [], updateTeacherSuccess: undefined };
 export const teacherActions = {
@@ -10,7 +10,6 @@ export const teacherActions = {
     const response = await fetch("/api/teachers");
     const teacherData = await response.json();
     commit(MUTATIONS.SET_TEACHERS, teacherData);
-    
   },
   async createTeacher({ dispatch }, teacherData) {
     const payload = {
@@ -24,9 +23,9 @@ export const teacherActions = {
     };
     const response = await fetch("api/teachers", payload);
     dispatch("getAllTeachers");
-    return response
+    return response;
   },
-  async patchTeacher({ dispatch, commit}, teacherData){
+  async patchTeacher({ dispatch, commit }, teacherData) {
     const payload = {
       method: "PATCH",
       headers: {
@@ -35,87 +34,93 @@ export const teacherActions = {
       },
       body: JSON.stringify(teacherData),
     };
-    const result = await fetch(`api/teachers/${teacherData.TeacherID}`, payload);
-    if(result.status < 400){
-      commit(MUTATIONS.SET_UPDATE_TEACHER_SUCCESS, true)
-      dispatch("getAllTeachers")
-
-    }
-    else{
-      commit(MUTATIONS.SET_UPDATE_TEACHER_SUCCESS, false)
+    const result = await fetch(
+      `api/teachers/${teacherData.TeacherID}`,
+      payload
+    );
+    if (result.status < 400) {
+      commit(MUTATIONS.SET_UPDATE_TEACHER_SUCCESS, true);
+      dispatch("getAllTeachers");
+    } else {
+      commit(MUTATIONS.SET_UPDATE_TEACHER_SUCCESS, false);
     }
   },
-  resetTeacherUpdateSuccess({commit}, value){
-    commit(MUTATIONS.SET_UPDATE_TEACHER_SUCCESS, value)
+  resetTeacherUpdateSuccess({ commit }, value) {
+    commit(MUTATIONS.SET_UPDATE_TEACHER_SUCCESS, value);
   },
 
-  async updateTeacherStatus({ commit, dispatch }, { teacherID, previousStatusString, nextStatusString, updatedBy, reason }) {
+  async updateTeacherStatus(
+    { commit, dispatch },
+    { teacherID, previousStatusString, nextStatusString, updatedBy, reason }
+  ) {
     // PATCH student
     const teacherRequestOptions = {
-        method: "PATCH",
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({TeacherID: teacherID, PreviousStatusString: previousStatusString, NextStatusString: nextStatusString})
-    }
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        TeacherID: teacherID,
+        PreviousStatusString: previousStatusString,
+        NextStatusString: nextStatusString,
+      }),
+    };
 
     // POST statusUpdate
     const statusUpdateRequestOptions = {
-        method: "POST",
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
         TeacherID: teacherID,
         PreviousStatusString: previousStatusString,
         NextStatusString: nextStatusString,
         UpdatedBy: updatedBy,
-        ReasonString: reason
-        })
-    }
+        ReasonString: reason,
+      }),
+    };
 
     fetch("/api/statusUpdates", statusUpdateRequestOptions)
-    .then((response) => {
-        if(response.status !== 200) {
-            throw new Error(response);
+      .then((response) => {
+        if (response.status !== 200) {
+          throw new Error(response);
         }
-        dispatch('getAllTeachers')
-        // Call deletion API 
-        fetch('/api/matches/teacher', {
+        dispatch("getAllTeachers");
+        // Call deletion API
+        fetch("/api/matches/unmatch-teacher", {
           method: "POST",
           headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
+            Accept: "application/json",
+            "Content-Type": "application/json",
           },
           body: JSON.stringify({
-          TeacherID: teacherID,
-          NextStatusString: nextStatusString,
-          })
-        })
+            TeacherID: teacherID,
+            NextStatusString: nextStatusString,
+          }),
+        });
         // TODO: Call matches API after this to refresh
-    })
-    .catch((err) => {
+      })
+      .catch((err) => {
         console.error(err);
-    });
-},
-
+      });
+  },
 };
 export const teacherMutations = {
   [MUTATIONS.SET_TEACHERS](state, teachers) {
     state.teachers = teachers;
   },
-  [MUTATIONS.SET_UPDATE_TEACHER_SUCCESS](state, value){
+  [MUTATIONS.SET_UPDATE_TEACHER_SUCCESS](state, value) {
     state.updateTeacherSuccess = value;
-  }
-
+  },
 };
 export const teacherGetters = {
   teachers(state) {
     return state.teachers;
   },
-  getTeacherByTeacherId:(state) => (id) => {
-    return state.teachers.find(teacher => teacher.TeacherID == id)
-  } 
+  getTeacherByTeacherId: (state) => (id) => {
+    return state.teachers.find((teacher) => teacher.TeacherID == id);
+  },
 };


### PR DESCRIPTION
# Unmatch Student Flow 

[IRRC-37](https://bootcamp-irrc.atlassian.net/browse/IRRC-37)

## Description

When a student's status is changed through their Profile Card (e.g. localhost:3000/students/2), we check if this student is their teacher's only student. If that is the case, the teacher's status is also changed to UNMATCHED. Then, we delete the match for this teacher and student in the matching table. 

API endpoint: /api/matches/unmatch-student (for teachers, it's unmatch-teacher)
<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Testing 
For student where 1 teacher:1 student
1. Create a new Student
2. Create a new Teacher
3. Match the Student and the Teacher
4. Go to the student's profile page and change their status to DROPPED OUT or UNMATCHED.
5. Go to api/matches and check if the match has been deleted. 
6. Go to the teacher's profile/teachers table and check if the teacher's status is now UNMATCHED. 

For student where 1 teacher: many students
Same as above, except Step 1 should create 2 (or more) students, and all of them should be matched to the same teacher.
Expected behaviour: 
If one student's status is changed to DROPPED OUT or UNMATCHED, their match should be deleted, but the teacher's status should remain the same (as the teacher is still MATCHED to other students). 
