### PR TITLE
Refactor students.vue to use b-table-column and status.vue component, added pagination

### DIFF
--- a/frontend/src/components/ProfileCard.vue
+++ b/frontend/src/components/ProfileCard.vue
@@ -1,32 +1,32 @@
 <template>
   <div class="card">
     <div class="edit-container">Edit</div>
-    <div class="student-grid">
+    <div class="profile-grid">
       <img v-if="isTeacher" src="../assets/teacher.png" />
       <img v-else src="../assets/images/student.png" />
-      <div class="student-label" v-if="isTeacher">Teacher</div>
-      <div class="student-label" v-else>Student</div>
-      <div class="student-main">{{ studentInfo.studentName }}</div>
-      <div class="student-main">{{ studentInfo.studentContact }}</div>
+      <div class="profile-label" v-if="isTeacher">Teacher</div>
+      <div class="profile-label" v-else>Student</div>
+      <div class="profile-main">{{ profile.name }}</div>
+      <div class="profile-main">{{ profile.contact }}</div>
       <div>
-        <div class="student-label-small padding-large">Date Joined</div>
-        <div class="student-detail">{{ studentInfo.dateJoined }}</div>
+        <div class="profile-label-small padding-large">Date Joined</div>
+        <div class="profile-detail">{{ profile.dateJoined }}</div>
       </div>
       <div>
-        <div class="student-label-small padding-large">Source</div>
-        <div class="student-detail">{{ studentInfo.source }}</div>
+        <div class="profile-label-small padding-large">Source</div>
+        <div class="profile-detail">{{ profile.source }}</div>
       </div>
       <div>
-        <div class="student-label-small padding-small">Native Language</div>
-        <div class="student-detail">{{ studentInfo.nativeLanguage }}</div>
+        <div class="profile-label-small padding-small">Native Language</div>
+        <div class="profile-detail">{{ profile.nativeLanguage }}</div>
       </div>
       <div>
-        <div class="student-label-small padding-small">English Proficiency</div>
+        <div class="profile-label-small padding-small">English Proficiency</div>
         <div>
           <b-select
             v-if="
-              studentInfo.status.toUpperCase() === 'SCREENING' &&
-              studentInfo.proficiencyLevel == null
+              profile.status.toUpperCase() === 'SCREENING' &&
+              profile.proficiencyLevel == null
             "
             placeholder="Select Proficiency"
             @change.native="selectedEnglishProficiency"
@@ -42,25 +42,25 @@
               Intermediate - Able to carry conversations
             </option>
           </b-select>
-          <div v-else class="student-detail">
-            {{ studentInfo.proficiencyLevel }}
+          <div v-else class="profile-detail">
+            {{ profile.proficiencyLevel }}
           </div>
         </div>
       </div>
       <div>
-        <div class="student-label-small padding-small" v-if="isTeacher">
+        <div class="profile-label-small padding-small" v-if="isTeacher">
           Second Language
         </div>
-        <div class="student-detail" v-if="isTeacher">
-          {{ teacherInfo.secondLanguage }}
+        <div class="profile-detail" v-if="isTeacher">
+          {{ profile.secondLanguage }}
         </div>
       </div>
       <div>
-        <div class="student-label-small padding-small" v-if="isTeacher">
+        <div class="profile-label-small padding-small" v-if="isTeacher">
           Language Proficiency
         </div>
-        <div class="student-detail" v-if="isTeacher">
-          {{ teacherInfo.languageProficiency }}
+        <div class="profile-detail" v-if="isTeacher">
+          {{ profile.languageProficiency }}
         </div>
       </div>
     </div>
@@ -68,34 +68,27 @@
     <hr />
     <div class="notes-label">Notes</div>
     <div class="notes-text">
-      {{ studentInfo.notes }}
+      {{ profile.notes }}
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  name: "StudentProfileCard",
+  name: "ProfileCard",
   props: {
-    studentInfo: {
+    profile: {
       type: Object,
       default: function () {
         return {
-          studentName: "Default Name",
-          studentContact: "9123 4567",
+          name: "Default Name",
+          contact: "9123 4567",
           dateJoined: "Sept 07 2020",
           source: "Rotary",
           nativeLanguage: "Bangla",
           notes: "Dummy Text",
           status: "Screening",
           proficiencyLevel: "Little (able to understand simple words)",
-        };
-      },
-    },
-    teacherInfo: {
-      type: Object,
-      default: function () {
-        return {
           secondLanguage: "Bangla",
           languageProficiency: "Intermediate",
         };
@@ -123,7 +116,7 @@ export default {
   text-align: right;
   color: #00488f;
 }
-.student-grid {
+.profile-grid {
   display: grid;
   grid-template-columns: 180px 1fr;
   grid-template-rows: min-content 38px repeat(3, min-content);
@@ -133,7 +126,7 @@ export default {
     grid-row: span 3;
   }
 
-  .student-label {
+  .profile-label {
     font-size: 12px;
     color: #59666e;
     text-transform: uppercase;
@@ -141,7 +134,7 @@ export default {
     padding-bottom: 12px;
   }
 
-  .student-main {
+  .profile-main {
     font-size: 24px;
     font-weight: 700;
     color: #12171a;
@@ -154,7 +147,7 @@ export default {
   .padding-small {
     padding-top: 24px;
   }
-  .student-label-small {
+  .profile-label-small {
     font-size: 14px;
     font-weight: 500;
     color: #59666e;
@@ -163,7 +156,7 @@ export default {
     padding-bottom: 2px;
   }
 
-  .student-detail {
+  .profile-detail {
     font-size: 16px;
     font-weight: 400;
     color: #12171a;

--- a/frontend/src/pages/Screening.vue
+++ b/frontend/src/pages/Screening.vue
@@ -37,6 +37,8 @@
           checkable
           :checkbox-position="checkboxPosition"
           :is-row-checkable="(row) => row.EnglishProficiency !== null"
+          :selected.sync="selected"
+          @dblclick="goToStudent"
         >
           <!-- Student ID column -->
 
@@ -106,7 +108,7 @@ import { mapGetters, mapActions, mapState } from "vuex";
 export default {
   data() {
     return {
-      selected: null,
+      selected: {},
       sortIcon: "arrow-up",
       sortIconSize: "is-small",
       sortDirection: "asc",
@@ -182,6 +184,9 @@ export default {
           this.patchScreeningStudents(patchStudentsData)
         }
       }) 
+    },
+    goToStudent() {
+      this.$router.push({ path: `/students/${this.selected.StudentID}` })
     }
   }
 };

--- a/frontend/src/pages/StudentProfile.vue
+++ b/frontend/src/pages/StudentProfile.vue
@@ -2,10 +2,10 @@
   <Page blueBg>
     <div class="student-profile-container">
       <div class="student-profile-left">
-        <StudentProfileCard
-          v-bind:studentInfo="{
-            studentName: studentData.FullName,
-            studentContact: studentData.PhoneNumber,
+        <ProfileCard
+          v-bind:profile="{
+            name: studentData.FullName,
+            contact: studentData.PhoneNumber,
             source: studentData.Source,
             dateJoined: studentData.dateJoined,
             nativeLanguage: studentData.nativeLanguage.NativeLanguage,
@@ -33,7 +33,7 @@
 
 <script>
 import Page from "../components/Page.vue";
-import StudentProfileCard from "../components/StudentProfileCard.vue";
+import ProfileCard from "../components/ProfileCard.vue";
 import StudentHistory from "../components/StudentHistory/StudentHistory.vue";
 import StatusCardMatched from "../components/statusCards/StatusCardMatched.vue";
 import StatusCardDroppedOut from "../components/statusCards/StatusCardDroppedOut.vue";
@@ -45,7 +45,7 @@ export default {
   name: "StudentProfile",
   components: {
     Page,
-    StudentProfileCard,
+    ProfileCard,
     StudentHistory,
     StatusCardMatched,
     StatusCardDroppedOut,

--- a/frontend/src/pages/Students.vue
+++ b/frontend/src/pages/Students.vue
@@ -2,7 +2,7 @@
   <Page>
     <div class="container">
       <div class="Title">
-        <b class="newStudent">All Students</b>
+        <b>All Students</b>
       </div>
       <!--start of table -->
       <section>
@@ -11,6 +11,8 @@
           :sort-icon="sortIcon"
           :sort-icon-size="sortIconSize"
           :sortDirection="sortDirection"
+          :selected.sync="selected"
+          @dblclick="goToStudent"
         >
           <!-- date column -->
 
@@ -176,7 +178,7 @@ import { mapActions } from "vuex";
 export default {
   data() {
     return {
-      selected: null,
+      selected: {},
       sortIcon: "arrow-up",
       sortIconSize: "is-small",
       sortDirection: "asc",
@@ -229,6 +231,9 @@ export default {
   },
   methods: {
     ...mapActions(["getAllStudents"]),
+    goToStudent() {
+      this.$router.push({ path: `/students/${this.selected.StudentID}` })
+    }
   },
   mounted() {
     this.getAllStudents();

--- a/frontend/src/pages/Students.vue
+++ b/frontend/src/pages/Students.vue
@@ -1,149 +1,121 @@
 <template>
   <Page>
-    <div class="container">
-      <div class="Title">
-        <b class="newStudent">All Students</b>
-      </div>
-      <!--start of table -->
-      <section>
-        <b-table
-          :data="tableData"
-          :sort-icon="sortIcon"
-          :sort-icon-size="sortIconSize"
-          :sortDirection="sortDirection"
-        >
-          <!-- date column -->
+    <PageHeader slot="header">
+    <a class="logo">All Students</a>
+    </PageHeader>   
+    <!--start of table -->
+    <section>
+      <b-table
+        :data="studentData"
+        :sort-icon="sortIcon"
+        :sort-icon-size="sortIconSize"
+        :sortDirection="sortDirection"
+        :paginated="isPaginated"
+        :per-page="perPage"
+        :current-page.sync="currentPage"
+      >
+        <!-- date column -->
 
-          <template v-for="(column, index) in columns" v-if="index == 0">
-            <b-table-column :key="column.id" v-bind="column" sortable>
+        <b-table-column field="CreatedAt" label="Date Joined" width="120" searchable sortable>
+            <template
+          slot="searchable"
+          slot-scope="props"
+          >
+          <b-tooltip label="Search: YYYY-MM-DD">
+              <b-input
+              v-model="props.filters[props.column.field]"
+              icon="magnify"
+              size="is-small"
+              />
+          </b-tooltip>
+          
+          </template>
+          <template v-slot="props">
+              
+              <span style="font-size: 14px">
+              {{
+                  new Date(props.row.CreatedAt)
+                  .toLocaleDateString("en-US", {
+                      day: "2-digit",
+                      month: "short",
+                      year: "numeric",
+                  })
+                  .replace(",", " ")
+              }}
+              </span>
+          </template>
+        </b-table-column>
+
+        <!-- Student Name/ID column -->
+
+        <b-table-column field="FullNameID" label="Student Name/ID" searchable sortable>
               <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-tooltip label="Search: YYYY-MM-DD">
-                  <b-input
-                    v-model="props.filters[props.column.field]"
-                    icon="magnify"
-                    size="is-small"
-                  />
-                </b-tooltip>
-              </template>
-              <template v-slot="props">
-                <span :class="['idStyle']">
-                  {{
-                    new Date(props.row.CreatedAt)
-                      .toLocaleDateString("en-US", {
-                        day: "2-digit",
-                        month: "short",
-                        year: "numeric",
-                      })
-                      .replace(",", " ")
-                  }}
+            slot="searchable"
+            slot-scope="props"
+            >
+            <b-input
+            v-model="props.filters[props.column.field]"
+            icon="magnify"
+            size="is-small"
+            />
+            </template>
+            <template v-slot="props">
+                <span class="name">
+                    {{props.row.FullName}}
                 </span>
-              </template>
-            </b-table-column>
-          </template>
-
-          <!-- Student ID column -->
-
-          <template v-for="(column, index) in columns" v-if="index == 1">
-            <b-table-column :key="column.id" v-bind="column" sortable>
-              <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-input
-                  v-model="props.filters[props.column.field]"
-                  icon="magnify"
-                  size="is-small"
-                />
-              </template>
-              <template v-slot="props">
-                <span>
-                  {{ props.row.StudentID }}
+                <br>
+                <span class="ID">
+                    {{props.row.StudentID}}
                 </span>
-              </template>
-            </b-table-column>
+            </template> 
+         </b-table-column>
+
+
+        <!-- status column -->
+
+        <b-table-column field="Status" label="Status" searchable sortable>
+          <template
+          slot="searchable"
+          slot-scope="props"
+          >
+          <b-input
+          v-model="props.filters[props.column.field]"
+          icon="magnify"
+          size="is-small"
+          />
           </template>
-
-          <!-- Student Name column -->
-
-          <template v-for="(column, index) in columns" v-if="index == 2">
-            <b-table-column :key="column.id" v-bind="column" sortable>
-              <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-input
-                  v-model="props.filters[props.column.field]"
-                  icon="magnify"
-                  size="is-small"
-                />
-              </template>
-              <template v-slot="props">
-                <span :class="['nameStyle']">
-                  {{ props.row.FullName }}
-                </span>
-                <br />
-              </template>
-            </b-table-column>
+          <template v-slot="props">
+              <Status :status="props.row.Status"></Status>
           </template>
+        </b-table-column>
 
-          <!-- status column -->
+        <!-- phone column -->
 
-          <template v-for="(column, index) in columns" v-if="index == 3">
-            <b-table-column :key="column.id" v-bind="column" sortable>
-              <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-input
-                  v-model="props.filters[props.column.field]"
-                  icon="magnify"
-                  size="is-small"
-                />
-              </template>
-              <template v-slot="props">
-                <Status :status="props.row.Status"></Status>
-              </template>
-            </b-table-column>
+        <b-table-column field="PhoneNumber" label="Phone Number" searchable sortable>
+          <template
+          slot="searchable"
+          slot-scope="props"
+          >
+          <b-input
+          v-model="props.filters[props.column.field]"
+          icon="magnify"
+          size="is-small"
+          />
           </template>
-
-          <!-- phone column -->
-
-          <template v-for="(column, index) in columns" v-if="index == 4">
-            <b-table-column :key="column.id" v-bind="column" sortable>
-              <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-input
-                  v-model="props.filters[props.column.field]"
-                  icon="magnify"
-                  size="is-small"
-                />
-              </template>
-              <template v-slot="props">
-                {{ props.row.PhoneNumber }}
-              </template>
-            </b-table-column>
+          <template v-slot="props">
+              {{ props.row.PhoneNumber }}
           </template>
-        </b-table>
-      </section>
-    </div>
+        </b-table-column>
+      </b-table>
+    </section>
   </Page>
 </template>
 
 <script>
-const API_URL = "/api/students";
 
 import PageHeader from "../components/PageHeader.vue";
 import Page from "../components/Page.vue";
+import Status from "../components/Status.vue"
 import { mapGetters } from "vuex";
 import { mapActions } from "vuex";
 import Status from "../components/Status.vue"
@@ -155,45 +127,24 @@ export default {
       sortIcon: "arrow-up",
       sortIconSize: "is-small",
       sortDirection: "asc",
-      columns: [
-        {
-          field: "CreatedAt",
-          label: "Date Joined",
-          searchable: true,
-        },
-        {
-          field: "StudentID",
-          label: "Student ID",
-          searchable: true,
-        },
-        {
-          field: "FullName",
-          label: "Student Name",
-          searchable: true,
-        },
-        {
-          field: "Status",
-          label: "Status",
-          searchable: true,
-        },
-        {
-          field: "PhoneNumber",
-          label: "Phone Number",
-          searchable: true,
-        },
-      ],
+      isPaginated: true,
+      paginationPosition:'bottom',
+      currentPage: 1,
+      perPage: 10,
     };
   },
   computed: {
     ...mapGetters(["students"]),
-    tableData() {
+    studentData() {
       return this.students.map((student) => {
         return {
+          ...student,
           StudentID: `${student.StudentID}`,
           FullName: `${student.FullName}`,
           CreatedAt: `${student.created_at}`,
           Status: `${student.status.Description}`,
           PhoneNumber: `${student.PhoneNumber}`,
+          FullNameID: `${student.FullName} <br> ${student.StudentID}`
         };
       });
     },
@@ -231,26 +182,6 @@ span.tag {
   padding-bottom: 25px;
   width: 185px;
 }
-span.tag.is-info {
-  background-color: rgba(159, 207, 255, 0.15);
-  color: #00488f;
-  font-size: 1em;
-  justify-content: left;
-  padding-top: 25px;
-  padding-bottom: 25px;
-}
-span.tag.is-success {
-  background-color: rgba(84, 140, 47, 0.15);
-  color: #255307;
-}
-span.tag.is-danger {
-  background-color: rgba(255, 166, 165, 0.15);
-  color: #be0e00;
-}
-span.tag.is-warning {
-  background-color: rgba(246, 174, 45, 0.08);
-  color: #f6ae2d;
-}
 span.idStyle {
   font-size: 0.8em;
 }
@@ -258,9 +189,13 @@ span.idStyle {
 .table th {
   color: #59666e;
 }
-span.nameStyle {
+span.name {
   color: #3c4f76 !important;
 }
+span.id{
+  color:#59666E !important;
+}
+
 table td:not([align]),
 table th:not([align]) {
   vertical-align: middle;
@@ -268,4 +203,14 @@ table th:not([align]) {
 .b-table .table th.is-current-sort .b-table .table th.is-sortable:hover {
   border-color: white !important;
 }
+
+.content ul{
+  list-style:none;
+}
+
+ul.pagination-list{
+  margin: 0 auto;
+}
+
+
 </style>

--- a/frontend/src/pages/Students.vue
+++ b/frontend/src/pages/Students.vue
@@ -118,7 +118,6 @@ import Page from "../components/Page.vue";
 import Status from "../components/Status.vue"
 import { mapGetters } from "vuex";
 import { mapActions } from "vuex";
-import Status from "../components/Status.vue"
 
 export default {
   data() {
@@ -174,16 +173,6 @@ body {
 .Title {
   padding-bottom: 20px;
   vertical-align: bottom !important;
-}
-span.tag {
-  font-size: 1em;
-  justify-content: left;
-  padding-top: 25px;
-  padding-bottom: 25px;
-  width: 185px;
-}
-span.idStyle {
-  font-size: 0.8em;
 }
 .table td,
 .table th {

--- a/frontend/src/pages/Students.vue
+++ b/frontend/src/pages/Students.vue
@@ -179,16 +179,6 @@ body {
   padding-bottom: 20px;
   vertical-align: bottom !important;
 }
-span.tag {
-  font-size: 1em;
-  justify-content: left;
-  padding-top: 25px;
-  padding-bottom: 25px;
-  width: 185px;
-}
-span.idStyle {
-  font-size: 0.8em;
-}
 .table td,
 .table th {
   color: #59666e;

--- a/frontend/src/pages/Students.vue
+++ b/frontend/src/pages/Students.vue
@@ -1,154 +1,125 @@
 <template>
   <Page>
-    <div class="container">
-      <div class="Title">
-        <b>All Students</b>
-      </div>
-      <!--start of table -->
-      <section>
-        <b-table
-          :data="tableData"
-          :sort-icon="sortIcon"
-          :sort-icon-size="sortIconSize"
-          :sortDirection="sortDirection"
-          :selected.sync="selected"
-          @dblclick="goToStudent"
+    <PageHeader slot="header">
+      <a class="logo">All Students</a>
+    </PageHeader>
+    <!--start of table -->
+    <section>
+      <b-table
+        :data="studentData"
+        :sort-icon="sortIcon"
+        :sort-icon-size="sortIconSize"
+        :sortDirection="sortDirection"
+        :paginated="isPaginated"
+        :per-page="perPage"
+        :current-page.sync="currentPage"
+        :selected.sync="selected"
+        @dblclick="goToStudent"
+      >
+        <!-- date column -->
+
+        <b-table-column
+          field="CreatedAt"
+          label="Date Joined"
+          width="120"
+          searchable
+          sortable
         >
-          <!-- date column -->
-
-          <template v-for="(column, index) in columns" v-if="index == 0">
-            <b-table-column :key="column.id" v-bind="column" sortable>
-              <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-tooltip label="Search: YYYY-MM-DD">
-                  <b-input
-                    v-model="props.filters[props.column.field]"
-                    icon="magnify"
-                    size="is-small"
-                  />
-                </b-tooltip>
-              </template>
-              <template v-slot="props">
-                <span :class="['idStyle']">
-                  {{
-                    new Date(props.row.CreatedAt)
-                      .toLocaleDateString("en-US", {
-                        day: "2-digit",
-                        month: "short",
-                        year: "numeric",
-                      })
-                      .replace(",", " ")
-                  }}
-                </span>
-              </template>
-            </b-table-column>
+          <template slot="searchable" slot-scope="props">
+            <b-tooltip label="Search: YYYY-MM-DD">
+              <b-input
+                v-model="props.filters[props.column.field]"
+                icon="magnify"
+                size="is-small"
+              />
+            </b-tooltip>
           </template>
-
-          <!-- Student ID column -->
-
-          <template v-for="(column, index) in columns" v-if="index == 1">
-            <b-table-column :key="column.id" v-bind="column" sortable>
-              <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-input
-                  v-model="props.filters[props.column.field]"
-                  icon="magnify"
-                  size="is-small"
-                />
-              </template>
-              <template v-slot="props">
-                <span>
-                  {{ props.row.StudentID }}
-                </span>
-              </template>
-            </b-table-column>
+          <template v-slot="props">
+            <span style="font-size: 14px">
+              {{
+                new Date(props.row.CreatedAt)
+                  .toLocaleDateString("en-US", {
+                    day: "2-digit",
+                    month: "short",
+                    year: "numeric",
+                  })
+                  .replace(",", " ")
+              }}
+            </span>
           </template>
+        </b-table-column>
 
-          <!-- Student Name column -->
+        <!-- Student Name/ID column -->
 
-          <template v-for="(column, index) in columns" v-if="index == 2">
-            <b-table-column :key="column.id" v-bind="column" sortable>
-              <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-input
-                  v-model="props.filters[props.column.field]"
-                  icon="magnify"
-                  size="is-small"
-                />
-              </template>
-              <template v-slot="props">
-                <span :class="['nameStyle']">
-                  {{ props.row.FullName }}
-                </span>
-                <br />
-              </template>
-            </b-table-column>
+        <b-table-column
+          field="FullNameID"
+          label="Student Name/ID"
+          searchable
+          sortable
+        >
+          <template slot="searchable" slot-scope="props">
+            <b-input
+              v-model="props.filters[props.column.field]"
+              icon="magnify"
+              size="is-small"
+            />
           </template>
-
-          <!-- status column -->
-
-          <template v-for="(column, index) in columns" v-if="index == 3">
-            <b-table-column :key="column.id" v-bind="column" sortable>
-              <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-input
-                  v-model="props.filters[props.column.field]"
-                  icon="magnify"
-                  size="is-small"
-                />
-              </template>
-              <template v-slot="props">
-                <Status :status="props.row.Status"></Status>
-              </template>
-            </b-table-column>
+          <template v-slot="props">
+            <span class="name">
+              {{ props.row.FullName }}
+            </span>
+            <br />
+            <span class="ID">
+              {{ props.row.StudentID }}
+            </span>
           </template>
+        </b-table-column>
 
-          <!-- phone column -->
+        <!-- status column -->
 
-          <template v-for="(column, index) in columns" v-if="index == 4">
-            <b-table-column :key="column.id" v-bind="column" sortable>
-              <template
-                v-if="column.searchable"
-                slot="searchable"
-                slot-scope="props"
-              >
-                <b-input
-                  v-model="props.filters[props.column.field]"
-                  icon="magnify"
-                  size="is-small"
-                />
-              </template>
-              <template v-slot="props">
-                {{ props.row.PhoneNumber }}
-              </template>
-            </b-table-column>
+        <b-table-column field="Status" label="Status" searchable sortable>
+          <template slot="searchable" slot-scope="props">
+            <b-input
+              v-model="props.filters[props.column.field]"
+              icon="magnify"
+              size="is-small"
+            />
           </template>
-        </b-table>
-      </section>
-    </div>
+          <template v-slot="props">
+            <Status :status="props.row.Status"></Status>
+          </template>
+        </b-table-column>
+
+        <!-- phone column -->
+
+        <b-table-column
+          field="PhoneNumber"
+          label="Phone Number"
+          searchable
+          sortable
+        >
+          <template slot="searchable" slot-scope="props">
+            <b-input
+              v-model="props.filters[props.column.field]"
+              icon="magnify"
+              size="is-small"
+            />
+          </template>
+          <template v-slot="props">
+            {{ props.row.PhoneNumber }}
+          </template>
+        </b-table-column>
+      </b-table>
+    </section>
   </Page>
 </template>
 
 <script>
-const API_URL = "/api/students";
-
 import PageHeader from "../components/PageHeader.vue";
 import Page from "../components/Page.vue";
+import Status from "../components/Status.vue";
 import { mapGetters } from "vuex";
 import { mapActions } from "vuex";
-import Status from "../components/Status.vue"
 
 export default {
   data() {
@@ -157,45 +128,24 @@ export default {
       sortIcon: "arrow-up",
       sortIconSize: "is-small",
       sortDirection: "asc",
-      columns: [
-        {
-          field: "CreatedAt",
-          label: "Date Joined",
-          searchable: true,
-        },
-        {
-          field: "StudentID",
-          label: "Student ID",
-          searchable: true,
-        },
-        {
-          field: "FullName",
-          label: "Student Name",
-          searchable: true,
-        },
-        {
-          field: "Status",
-          label: "Status",
-          searchable: true,
-        },
-        {
-          field: "PhoneNumber",
-          label: "Phone Number",
-          searchable: true,
-        },
-      ],
+      isPaginated: true,
+      paginationPosition: "bottom",
+      currentPage: 1,
+      perPage: 10,
     };
   },
   computed: {
     ...mapGetters(["students"]),
-    tableData() {
+    studentData() {
       return this.students.map((student) => {
         return {
+          ...student,
           StudentID: `${student.StudentID}`,
           FullName: `${student.FullName}`,
           CreatedAt: `${student.created_at}`,
           Status: `${student.status.Description}`,
           PhoneNumber: `${student.PhoneNumber}`,
+          FullNameID: `${student.FullName} <br> ${student.StudentID}`,
         };
       });
     },
@@ -203,13 +153,13 @@ export default {
   components: {
     Page,
     PageHeader,
-    Status
+    Status,
   },
   methods: {
     ...mapActions(["getAllStudents"]),
     goToStudent() {
-      this.$router.push({ path: `/students/${this.selected.StudentID}` })
-    }
+      this.$router.push({ path: `/students/${this.selected.StudentID}` });
+    },
   },
   mounted() {
     this.getAllStudents();
@@ -236,26 +186,6 @@ span.tag {
   padding-bottom: 25px;
   width: 185px;
 }
-span.tag.is-info {
-  background-color: rgba(159, 207, 255, 0.15);
-  color: #00488f;
-  font-size: 1em;
-  justify-content: left;
-  padding-top: 25px;
-  padding-bottom: 25px;
-}
-span.tag.is-success {
-  background-color: rgba(84, 140, 47, 0.15);
-  color: #255307;
-}
-span.tag.is-danger {
-  background-color: rgba(255, 166, 165, 0.15);
-  color: #be0e00;
-}
-span.tag.is-warning {
-  background-color: rgba(246, 174, 45, 0.08);
-  color: #f6ae2d;
-}
 span.idStyle {
   font-size: 0.8em;
 }
@@ -263,14 +193,26 @@ span.idStyle {
 .table th {
   color: #59666e;
 }
-span.nameStyle {
+span.name {
   color: #3c4f76 !important;
 }
+span.id {
+  color: #59666e !important;
+}
+
 table td:not([align]),
 table th:not([align]) {
   vertical-align: middle;
 }
 .b-table .table th.is-current-sort .b-table .table th.is-sortable:hover {
   border-color: white !important;
+}
+
+.content ul {
+  list-style: none;
+}
+
+ul.pagination-list {
+  margin: 0 auto;
 }
 </style>

--- a/frontend/src/pages/TeacherProfile.vue
+++ b/frontend/src/pages/TeacherProfile.vue
@@ -2,18 +2,16 @@
   <Page blueBg>
     <div class="teacher-profile-container">
       <div class="teacher-profile-left">
-        <StudentProfileCard
-          v-bind:studentInfo="{
-            studentName: teacherData.FullName,
-            studentContact: teacherData.PhoneNumber,
+        <ProfileCard
+          v-bind:profile="{
+            name: teacherData.FullName,
+            contact: teacherData.PhoneNumber,
             source: teacherData.Source,
             dateJoined: teacherData.dateJoined,
             nativeLanguage: teacherData.nativeLanguage.NativeLanguage,
             notes: teacherData.Notes,
             status: teacherData.status.Description,
             proficiencyLevel: teacherData.EnglishProficiency,
-          }"
-          v-bind:teacherInfo="{
             secondLanguage: teacherData.secondLanguage.NativeLanguage,
             languageProficiency: teacherData.LanguageProficiency,
           }"
@@ -56,7 +54,7 @@
 
 <script>
 import Page from "../components/Page.vue";
-import StudentProfileCard from "../components/StudentProfileCard.vue";
+import ProfileCard from "../components/ProfileCard.vue";
 import StudentHistory from "../components/StudentHistory/StudentHistory.vue";
 import StatusCardMatched from "../components/statusCards/StatusCardMatched.vue";
 import StatusCardDroppedOut from "../components/statusCards/StatusCardDroppedOut.vue";
@@ -67,7 +65,7 @@ export default {
   name: "TeacherProfile",
   components: {
     Page,
-    StudentProfileCard,
+    ProfileCard,
     StudentHistory,
     StatusCardMatched,
     StatusCardDroppedOut,

--- a/frontend/src/pages/Teachers.vue
+++ b/frontend/src/pages/Teachers.vue
@@ -7,7 +7,10 @@
         
         <section>
             <b-table
-            :data="teachersData">
+            :data="teachersData"
+            :selected.sync="selected"
+            @dblclick="goToTeacher"
+            >
                 <b-table-column field="created_at" label="Date Joined" width="120" searchable sortable>
                      <template
                     slot="searchable"
@@ -139,9 +142,16 @@ export default {
         },
         ...mapGetters(['teachers'])
     },
+    data() {
+        return {
+          selected: {},
+        }
+    },
     methods: {
-        ...mapActions(['getAllTeachers'])
-
+        ...mapActions(['getAllTeachers']),
+        goToTeacher() {
+          this.$router.push({ path: `/teachers/${this.selected.TeacherID}` })
+        }
     },
     mounted() {
         this.getAllTeachers()


### PR DESCRIPTION
<!-- Name of the Pull Request -->
# Refactor students.vue to use b-table-column and status.vue components, and added pagination

<!-- JIRA Issue Number -->
Addresses issue #122 

<!-- Please describe the changes in your Pull Request -->
## Description
Refactors the All Students table to: 
- Remove use of mix of loops and conditionals by using `b-table-column`
- Used `status.vue` component
- Added pagination so that a maximum of 10 students is displayed on the table, students spill over to the next page once that number is exceeded
- Removed css styling that is no longer used as they are moved to the `status.vue` component

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Create more than 10 students
2. Go to `Student.vue` on the front-end
