### PR TITLE
Create teacher without SecondLanguage or LanguageProficiency in NewTeacher.vue

### DIFF
--- a/frontend/src/pages/NewTeacher.vue
+++ b/frontend/src/pages/NewTeacher.vue
@@ -238,7 +238,7 @@ export default {
         }),
         EnglishProficiency: this.EnglishProficiency,
         Notes: this.Notes,
-        StatusString: "SCREENING",
+        StatusString: "UNMATCHED",
       };
 
       this.createTeacher(teacherData).then((response) => {

--- a/frontend/src/pages/NewTeacher.vue
+++ b/frontend/src/pages/NewTeacher.vue
@@ -121,6 +121,7 @@
                   <b-select
                     v-model="SecondLanguageProficiency"
                     placeholder="Select one"
+                    :disabled="isDisabled"
                     expanded
                   >
                     <option value="Little">
@@ -185,6 +186,7 @@ export default {
       SecondLanguage: "",
       file: null,
       Notes: "",
+      isDisabled: true,
       selected: {
         NativeLanguage: "",
         SecondLanguage: "",
@@ -230,11 +232,13 @@ export default {
         Source: this.source,
         Email: this.Email,
         NativeLanguageString: this.selected.NativeLanguage,
-        SecondLanguageString: this.selected.SecondLanguage,
+        ...(this.selected.SecondLanguage && {
+          SecondLanguageString: this.selected.SecondLanguage,
+          LanguageProficiency: this.SecondLanguageProficiency,
+        }),
         EnglishProficiency: this.EnglishProficiency,
-        LanguageProficiency: this.SecondLanguageProficiency,
         Notes: this.Notes,
-        StatusString: "UNMATCHED",
+        StatusString: "SCREENING",
       };
 
       this.createTeacher(teacherData).then((response) => {
@@ -268,6 +272,9 @@ export default {
         );
       });
       this.checkLanguageExists = this.languageExists.length;
+      if (this.SecondLanguage != "") {
+        this.isDisabled = !this.isDisabled;
+      }
       if (this.SecondLanguage != "" && this.checkLanguageExists !== 1) {
         this.$buefy.notification.open({
           message:


### PR DESCRIPTION

<!-- Name of the Pull Request -->
# Disable language proficiency fields if no input for second language & exclude second language string and language proficiency when posting to teachers endpoint

<!-- JIRA Issue Number -->
#124 

<!-- Please describe the changes in your Pull Request -->
## Disabled language proficiency field unless an input is detected for second language. If there is no input for a Second Language, the `Second language String` and `Language Proficiency` fields are also excluded from the post to teachers endpoint.

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Create a new Teacher 
2. Fill in all fields except for Second Language, and Language Proficiency 
3. Submit 
4. New teacher should be created 
