### PR TITLE
Remove extra table in Teachers.vue

### DIFF
--- a/frontend/src/pages/Teachers.vue
+++ b/frontend/src/pages/Teachers.vue
@@ -40,40 +40,6 @@
             </span>
           </template>
         </b-table-column>
-      </b-table>
-    </section>
-    <section>
-      <b-table :data="teachersData">
-        <b-table-column
-          field="created_at"
-          label="Date Joined"
-          width="120"
-          searchable
-          sortable
-        >
-          <template slot="searchable" slot-scope="props">
-            <b-tooltip label="Search: YYYY-MM-DD">
-              <b-input
-                v-model="props.filters[props.column.field]"
-                icon="magnify"
-                size="is-small"
-              />
-            </b-tooltip>
-          </template>
-          <template v-slot="props">
-            <span style="font-size: 14px">
-              {{
-                new Date(props.row.created_at)
-                  .toLocaleDateString("en-US", {
-                    day: "2-digit",
-                    month: "short",
-                    year: "numeric",
-                  })
-                  .replace(",", " ")
-              }}
-            </span>
-          </template>
-        </b-table-column>
 
         <b-table-column
           field="FullNameID"
@@ -161,6 +127,7 @@ export default {
     Status,
   },
   computed: {
+    ...mapGetters(["teachers", "suggestedTeachers"]),
     teachersData() {
       return this.teachers.map((item) => {
         return {
@@ -169,21 +136,20 @@ export default {
         };
       });
     },
-    ...mapGetters(["teachers", "suggestedTeachers"]),
-    data() {
-      return {
-        selected: {},
-      };
+  },
+  data() {
+    return {
+      selected: {},
+    };
+  },
+  methods: {
+    ...mapActions(["getAllTeachers"]),
+    goToTeacher() {
+      this.$router.push({ path: `/teachers/${this.selected.TeacherID}` });
     },
-    methods: {
-      ...mapActions(["getAllTeachers"]),
-      goToTeacher() {
-        this.$router.push({ path: `/teachers/${this.selected.TeacherID}` });
-      },
-    },
-    mounted() {
-      this.getAllTeachers();
-    },
+  },
+  mounted() {
+    this.getAllTeachers();
   },
 };
 </script>


### PR DESCRIPTION
Remove extra table in Teachers.vue

There was an extra table in `Teachers.vue`.

## Test Steps
1. Create a new Teacher
2. Navigate to `localhost:3000/teachers`. You should see the new teacher listed.
3. Double-click the teacher. This should lead you to the individual Teacher Profile.
