### PR TITLE
[Refactor] Move generic helpers out of helpers/students

### DIFF
--- a/backend/src/helpers/nativeLanguages.js
+++ b/backend/src/helpers/nativeLanguages.js
@@ -1,19 +1,44 @@
-const db = require('../models/nativeLanguage')
+const db = require("../models/nativeLanguage");
 
 exports.addNativeLanguage = async function (nativeLanguage) {
   try {
-    const response = await db.NativeLanguage.query().insert(nativeLanguage)
-    return response
+    const response = await db.NativeLanguage.query().insert(nativeLanguage);
+    return response;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
 exports.getNativeLanguageByString = async function (nativeLanguageString) {
   try {
-    const response = await db.NativeLanguage.query().findOne('NativeLanguage', 'ilike', nativeLanguageString)
-    return response
+    const response = await db.NativeLanguage.query().findOne(
+      "NativeLanguage",
+      "ilike",
+      nativeLanguageString
+    );
+    return response;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
+
+exports.getNativeLanguagePromise = async function (nativeLanguageString) {
+  if (nativeLanguageString != null) {
+    const nativeLanguageResponse = await nativeLanguages.getNativeLanguageByString(
+      nativeLanguageString
+    );
+    if (nativeLanguageResponse && !nativeLanguageResponse.err) {
+      return nativeLanguageResponse;
+    } else if (!nativeLanguageResponse) {
+      const newNativeLanguage = await nativeLanguages.addNativeLanguage({
+        NativeLanguage: nativeLanguageString.toUpperCase(),
+      });
+      return newNativeLanguage;
+    } else {
+      throw nativeLanguageResponse.err;
+    }
+  } else {
+    // If NativeLanguage is empty, will throw an error
+    throw new Error("NativeLanguageString or NativeLanguageID is required");
+  }
+};

--- a/backend/src/helpers/statuses.js
+++ b/backend/src/helpers/statuses.js
@@ -1,11 +1,24 @@
-const db = require('../models/status')
+const db = require("../models/status");
 
 exports.getStatusByStatusString = async function (statusString) {
   try {
-    const response = await db.Status.query()
-      .findOne('Description', 'ilike', statusString)
-    return response
+    const response = await db.Status.query().findOne(
+      "Description",
+      "ilike",
+      statusString
+    );
+    return response;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
+
+exports.getStatusPromise = async function (statusString) {
+  if (statusString != null) {
+    // If request contains StatusString, return corresponding StatusID
+    return statuses.getStatusByStatusString(statusString);
+  } else {
+    // If StatusID and StatusString are both not provided, default to 'SCREENING' StatusID
+    return statuses.getStatusByStatusString("SCREENING");
+  }
+};

--- a/backend/src/helpers/students.js
+++ b/backend/src/helpers/students.js
@@ -1,98 +1,92 @@
-const db = require('../models/student')
+const db = require("../models/student");
 // const debug = require('debug')('app:students')
-const statuses = require('./statuses')
-const nativeLanguages = require('./nativeLanguages')
+const statuses = require("./statuses");
+const nativeLanguages = require("./nativeLanguages");
 
 const defaultOptions = {
-  filters: {}
-}
+  filters: {},
+};
 exports.getAllStudents = async function (options = defaultOptions) {
-  const filterStatus = options.filters.status
+  const filterStatus = options.filters.status;
 
-  let query = db.Student.query().withGraphJoined('[nativeLanguage, status, statusUpdates.[nextStatus, reason]]')
+  let query = db.Student.query().withGraphJoined(
+    "[nativeLanguage, status, statusUpdates.[nextStatus, reason]]"
+  );
 
   if (filterStatus) {
-    query = query
-      .where('status.Description', 'ilike', filterStatus)
+    query = query.where("status.Description", "ilike", filterStatus);
   }
 
   try {
-    const students = await query.select()
-    return students
+    const students = await query.select();
+    return students;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
 exports.getStudentById = async function (id) {
   try {
     const student = await db.Student.query()
       .findById(id)
-      .withGraphFetched('[nativeLanguage, status, statusUpdates.[nextStatus, reason]]')
-      .throwIfNotFound()
-    return student // return student[0] || 'Not found'
+      .withGraphFetched(
+        "[nativeLanguage, status, statusUpdates.[nextStatus, reason]]"
+      )
+      .throwIfNotFound();
+    return student; // return student[0] || 'Not found'
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
 exports.addStudent = async function (student) {
   try {
-    const response = await db.Student.query().insert(student)
-    return response
+    const response = await db.Student.query().insert(student);
+    return response;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
 exports.patchStudent = async function (id, patchStudent) {
   // debug("test update notes")
   try {
     const response = await db.Student.query()
       .patchAndFetchById(id, patchStudent)
-      .throwIfNotFound()
-    return response
+      .throwIfNotFound();
+    return response;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
 exports.getStatusByStudentId = async function (studentID) {
   try {
     // This is the only executed query in this example.
-    const status = await db.Student.relatedQuery('status').for(studentID)
-    return status
+    const status = await db.Student.relatedQuery("status").for(studentID);
+    return status;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
-exports.getStatusPromise = async function (statusString) {
-  if (statusString != null) {
-    // If request contains StatusString, return corresponding StatusID
-    return statuses.getStatusByStatusString(statusString)
-  } else {
-    // If StatusID and StatusString are both not provided, default to 'SCREENING' StatusID
-    return statuses.getStatusByStatusString('SCREENING')
-  }
-}
 exports.getNativeLanguagePromise = async function (nativeLanguageString) {
   if (nativeLanguageString != null) {
     const nativeLanguageResponse = await nativeLanguages.getNativeLanguageByString(
       nativeLanguageString
-    )
+    );
     if (nativeLanguageResponse && !nativeLanguageResponse.err) {
-      return nativeLanguageResponse
+      return nativeLanguageResponse;
     } else if (!nativeLanguageResponse) {
       const newNativeLanguage = await nativeLanguages.addNativeLanguage({
-        NativeLanguage: nativeLanguageString.toUpperCase()
-      })
-      return newNativeLanguage
+        NativeLanguage: nativeLanguageString.toUpperCase(),
+      });
+      return newNativeLanguage;
     } else {
-      throw nativeLanguageResponse.err
+      throw nativeLanguageResponse.err;
     }
   } else {
     // If NativeLanguage is empty, will throw an error
-    throw new Error('NativeLanguageString or NativeLanguageID is required')
+    throw new Error("NativeLanguageString or NativeLanguageID is required");
   }
-}
+};

--- a/backend/src/helpers/students.js
+++ b/backend/src/helpers/students.js
@@ -69,24 +69,3 @@ exports.getStatusByStudentId = async function (studentID) {
     return { err };
   }
 };
-
-exports.getNativeLanguagePromise = async function (nativeLanguageString) {
-  if (nativeLanguageString != null) {
-    const nativeLanguageResponse = await nativeLanguages.getNativeLanguageByString(
-      nativeLanguageString
-    );
-    if (nativeLanguageResponse && !nativeLanguageResponse.err) {
-      return nativeLanguageResponse;
-    } else if (!nativeLanguageResponse) {
-      const newNativeLanguage = await nativeLanguages.addNativeLanguage({
-        NativeLanguage: nativeLanguageString.toUpperCase(),
-      });
-      return newNativeLanguage;
-    } else {
-      throw nativeLanguageResponse.err;
-    }
-  } else {
-    // If NativeLanguage is empty, will throw an error
-    throw new Error("NativeLanguageString or NativeLanguageID is required");
-  }
-};

--- a/backend/src/helpers/teachers.js
+++ b/backend/src/helpers/teachers.js
@@ -1,75 +1,68 @@
-const db = require('../models/teacher')
-const statuses = require('./statuses')
+const db = require("../models/teacher");
+const statuses = require("./statuses");
 
 exports.addTeacher = async function (teacher) {
   try {
-    const response = await db.Teacher.query().insert(teacher)
-    return response
+    const response = await db.Teacher.query().insert(teacher);
+    return response;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
 const defaultOptions = {
-  filters: {}
-}
+  filters: {},
+};
 exports.getAllTeachers = async function (options = defaultOptions) {
-  const filterStatus = options.filters.status
+  const filterStatus = options.filters.status;
 
-  let query = db.Teacher.query().withGraphJoined('[nativeLanguage, secondLanguage, status, statusUpdates.nextStatus]')
+  let query = db.Teacher.query().withGraphJoined(
+    "[nativeLanguage, secondLanguage, status, statusUpdates.nextStatus]"
+  );
 
   if (filterStatus) {
-    query = query
-      .where('status.Description', 'ilike', filterStatus)
+    query = query.where("status.Description", "ilike", filterStatus);
   }
 
   try {
-    const teachers = await query.select()
-    return teachers
+    const teachers = await query.select();
+    return teachers;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
 exports.getTeacherById = async function (id) {
   try {
     const teacher = await db.Teacher.query()
       .findById(id)
-      .withGraphFetched('[nativeLanguage, status, statusUpdates.[nextStatus, reason]]')
-      .throwIfNotFound()
-    return teacher
+      .withGraphFetched(
+        "[nativeLanguage, status, statusUpdates.[nextStatus, reason]]"
+      )
+      .throwIfNotFound();
+    return teacher;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
 exports.patchTeacher = async function (id, patchTeacher) {
   try {
     const response = await db.Teacher.query()
       .patchAndFetchById(id, patchTeacher)
-      .throwIfNotFound()
-    return response
+      .throwIfNotFound();
+    return response;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
 
 exports.getStatusByTeacherId = async function (teacherID) {
   try {
     // This is the only executed query in this example.
-    const status = await db.Teacher.relatedQuery('status').for(teacherID)
-    return status
+    const status = await db.Teacher.relatedQuery("status").for(teacherID);
+    return status;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
-
-exports.getStatusPromise = async function (statusString) {
-  if (statusString != null) {
-    // If request contains StatusString, return corresponding StatusID
-    return statuses.getStatusByStatusString(statusString)
-  } else {
-    // If StatusID and StatusString are both not provided, default to 'SCREENING' StatusID
-    return statuses.getStatusByStatusString('SCREENING')
-  }
-}
+};

--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -1,215 +1,215 @@
-const express = require('express')
-const router = express.Router()
+const express = require("express");
+const router = express.Router();
 // const debug = require('debug')('app:students')
-const students = require('../helpers/students')
-const statuses = require('../helpers/statuses')
+const students = require("../helpers/students");
+const statuses = require("../helpers/statuses");
 
-const { UniqueViolationError } = require('objection')
-const { NotFoundError } = require('objection')
+const { UniqueViolationError } = require("objection");
+const { NotFoundError } = require("objection");
 
 /* GET students listing. */
-router.get('/', async (req, res) => {
-  const status = req.query.status
+router.get("/", async (req, res) => {
+  const status = req.query.status;
   const result = await students.getAllStudents({
     filters: {
-      status
-    }
-  })
+      status,
+    },
+  });
 
   // handle error
   if (result.err) {
     // console.log('entered result.err')
-    const err = result.err
+    const err = result.err;
     res.status(500).send({
       message: err.message,
-      type: 'UnknownError',
-      data: {}
-    })
-    return
+      type: "UnknownError",
+      data: {},
+    });
+    return;
   }
 
-  res.json(result)
-})
+  res.json(result);
+});
 
 /* GET student by ID */
-router.get('/:id', async (req, res) => {
-  const result = await students.getStudentById(req.params.id)
+router.get("/:id", async (req, res) => {
+  const result = await students.getStudentById(req.params.id);
   //  console.log(result.err)
 
   // handle error
   if (result.err) {
-    const err = result.err
+    const err = result.err;
     if (err instanceof NotFoundError) {
       res.status(409).send({
         message: err.message,
-        type: 'StudentNotFound',
-        data: {}
-      })
+        type: "StudentNotFound",
+        data: {},
+      });
     } else {
       res.status(500).send({
         message: err.message,
-        type: 'UnknownError',
-        data: {}
-      })
+        type: "UnknownError",
+        data: {},
+      });
     }
 
-    return
+    return;
   }
 
-  res.json(result)
-})
+  res.json(result);
+});
 
 /* POST students listing */
-router.post('/', async (req, res) => {
+router.post("/", async (req, res) => {
   // If EnglishProficiency is empty
   if (!req.body.EnglishProficiency || req.body.EnglishProficiency === "") {
-    delete req.body.EnglishProficiency
+    delete req.body.EnglishProficiency;
   }
   // If request does not contain StatusID
   if (req.body.StatusID == null) {
-    let statusString
+    let statusString;
     // If request contains a statusString
     if (req.body.StatusString != null) {
-      statusString = req.body.StatusString
-      delete req.body.StatusString
+      statusString = req.body.StatusString;
+      delete req.body.StatusString;
     }
-    const status = await students.getStatusPromise(statusString)
-    req.body.StatusID = status.StatusID
+    const status = await statuses.getStatusPromise(statusString);
+    req.body.StatusID = status.StatusID;
   }
 
   // If request does not contain NativeLanguageID
   try {
     if (req.body.NativeLanguageID == null) {
-      let nativeLanguageString
+      let nativeLanguageString;
       // If request contains a nativeLanguageString
       if (req.body.NativeLanguageString != null) {
-        nativeLanguageString = req.body.NativeLanguageString
-        delete req.body.NativeLanguageString
+        nativeLanguageString = req.body.NativeLanguageString;
+        delete req.body.NativeLanguageString;
       }
       const nativeLanguage = await students.getNativeLanguagePromise(
         nativeLanguageString
-      )
-      req.body.NativeLanguageID = nativeLanguage.NativeLanguageID
+      );
+      req.body.NativeLanguageID = nativeLanguage.NativeLanguageID;
     }
   } catch (err) {
     res.status(400).send({
       message: err.message,
-      type: 'MissingParams',
-      data: {}
-    })
+      type: "MissingParams",
+      data: {},
+    });
   }
 
-  const result = await students.addStudent(req.body)
+  const result = await students.addStudent(req.body);
 
   // handle error
   if (result.err) {
-    const err = result.err
+    const err = result.err;
     if (err instanceof UniqueViolationError) {
       res.status(409).send({
         message: err.message,
-        type: 'UniqueViolation',
+        type: "UniqueViolation",
         data: {
           columns: err.columns,
           table: err.table,
-          constraint: err.constraint
-        }
-      })
+          constraint: err.constraint,
+        },
+      });
     } else {
       res.status(500).send({
         message: err.message,
-        type: 'UnknownError',
-        data: {}
-      })
+        type: "UnknownError",
+        data: {},
+      });
     }
 
-    return
+    return;
   }
 
-  res.status(200).json(result)
-})
+  res.status(200).json(result);
+});
 
 /* PATCH student listing */
 // on Postman: http://localhost:3001/students/1
-router.patch('/:id', async (req, res) => {
+router.patch("/:id", async (req, res) => {
   if (req.body.NativeLanguageString) {
     try {
       const nativeLanguage = await students.getNativeLanguagePromise(
         req.body.NativeLanguageString
-      )
-      req.body.NativeLanguageID = nativeLanguage.NativeLanguageID
-      delete req.body.NativeLanguageString
+      );
+      req.body.NativeLanguageID = nativeLanguage.NativeLanguageID;
+      delete req.body.NativeLanguageString;
     } catch (err) {
       return res.status(500).send({
         message: err.message,
-        type: 'UnknownError with NativeLanguage',
-        data: {}
-      })
+        type: "UnknownError with NativeLanguage",
+        data: {},
+      });
     }
   }
   // If EnglishProficiency is empty, delete it from the request body
   if (!req.body.EnglishProficiency || req.body.EnglishProficiency === "") {
-    delete req.body.EnglishProficiency
+    delete req.body.EnglishProficiency;
   }
   // If request does not contain StatusID and contains a StatusString
   if (req.body.StatusID == null && req.body.StatusString != null) {
-    const statusString = req.body.StatusString
-    delete req.body.StatusString
-    const status = await statuses.getStatusByStatusString(statusString)
-    req.body.StatusID = status.StatusID
+    const statusString = req.body.StatusString;
+    delete req.body.StatusString;
+    const status = await statuses.getStatusByStatusString(statusString);
+    req.body.StatusID = status.StatusID;
   }
 
   const result = await students.patchStudent(req.params.id, req.body);
 
   // handle error
   if (result.err) {
-    const err = result.err
+    const err = result.err;
     if (err instanceof NotFoundError) {
       res.status(409).send({
         message: err.message,
-        type: 'StudentNotFound',
-        data: {}
-      })
+        type: "StudentNotFound",
+        data: {},
+      });
     } else {
       res.status(500).send({
         message: err.message,
-        type: 'UnknownError. Database contraints may be violated',
-        data: {}
-      })
+        type: "UnknownError. Database contraints may be violated",
+        data: {},
+      });
     }
 
-    return
+    return;
   }
-  res.status(200).json(result)
-})
+  res.status(200).json(result);
+});
 
 /* GET status by StudentID */
-router.get('/:id/status', async (req, res) => {
-  const result = await students.getStatusByStudentId(req.params.id)
+router.get("/:id/status", async (req, res) => {
+  const result = await students.getStatusByStudentId(req.params.id);
   // console.log(result.err)
 
   // if student not found
   if (result.length === 0) {
     res.status(409).send({
-      message: 'StudentNotFound',
-      type: 'StudentNotFound',
-      data: {}
-    })
-    return
+      message: "StudentNotFound",
+      type: "StudentNotFound",
+      data: {},
+    });
+    return;
   }
 
   // handle error
   if (result.err) {
     // console.log('entered result.err')
-    const err = result.err
+    const err = result.err;
     res.status(500).send({
       message: err.message,
-      type: 'UnknownError',
-      data: {}
-    })
-    return
+      type: "UnknownError",
+      data: {},
+    });
+    return;
   }
 
-  res.json(result)
-})
+  res.json(result);
+});
 
-module.exports = router
+module.exports = router;

--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 // const debug = require('debug')('app:students')
+const nativeLanguages = require("../helpers/nativeLanguages");
 const students = require("../helpers/students");
 const statuses = require("../helpers/statuses");
 
@@ -86,7 +87,7 @@ router.post("/", async (req, res) => {
         nativeLanguageString = req.body.NativeLanguageString;
         delete req.body.NativeLanguageString;
       }
-      const nativeLanguage = await students.getNativeLanguagePromise(
+      const nativeLanguage = await nativeLanguages.getNativeLanguagePromise(
         nativeLanguageString
       );
       req.body.NativeLanguageID = nativeLanguage.NativeLanguageID;
@@ -133,7 +134,7 @@ router.post("/", async (req, res) => {
 router.patch("/:id", async (req, res) => {
   if (req.body.NativeLanguageString) {
     try {
-      const nativeLanguage = await students.getNativeLanguagePromise(
+      const nativeLanguage = await nativeLanguages.getNativeLanguagePromise(
         req.body.NativeLanguageString
       );
       req.body.NativeLanguageID = nativeLanguage.NativeLanguageID;

--- a/backend/src/routes/teachers.js
+++ b/backend/src/routes/teachers.js
@@ -2,7 +2,7 @@ const express = require("express");
 const router = express.Router();
 
 const statuses = require("../helpers/statuses");
-const students = require("../helpers/students");
+const nativeLanguages = require("../helpers/nativeLanguages");
 const teachers = require("../helpers/teachers");
 
 const { UniqueViolationError } = require("objection");
@@ -55,7 +55,7 @@ router.post("/", async (req, res) => {
         nativeLanguageString = req.body.NativeLanguageString;
         delete req.body.NativeLanguageString;
       }
-      const nativeLanguage = await students.getNativeLanguagePromise(
+      const nativeLanguage = await nativeLanguages.getNativeLanguagePromise(
         nativeLanguageString
       );
       req.body.NativeLanguageID = nativeLanguage.NativeLanguageID;
@@ -76,7 +76,7 @@ router.post("/", async (req, res) => {
       if (req.body.SecondLanguageString != null) {
         secondLanguageString = req.body.SecondLanguageString;
         delete req.body.SecondLanguageString;
-        const secondLanguage = await students.getNativeLanguagePromise(
+        const secondLanguage = await nativeLanguages.getNativeLanguagePromise(
           secondLanguageString
         );
         req.body.SecondLanguageID = secondLanguage.NativeLanguageID;
@@ -122,7 +122,7 @@ router.post("/", async (req, res) => {
 router.patch("/:id", async (req, res) => {
   if (req.body.NativeLanguageString) {
     try {
-      const nativeLanguage = await students.getNativeLanguagePromise(
+      const nativeLanguage = await nativeLanguages.getNativeLanguagePromise(
         req.body.NativeLanguageString
       );
       req.body.NativeLanguageID = nativeLanguage.NativeLanguageID;
@@ -138,7 +138,7 @@ router.patch("/:id", async (req, res) => {
 
   if (req.body.SecondLanguageString) {
     try {
-      const secondLanguage = await students.getNativeLanguagePromise(
+      const secondLanguage = await nativeLanguages.getNativeLanguagePromise(
         req.body.SecondLanguageString
       );
       req.body.SecondLanguageID = secondLanguage.NativeLanguageID;

--- a/backend/src/routes/teachers.js
+++ b/backend/src/routes/teachers.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 
+const statuses = require("../helpers/statuses");
 const students = require("../helpers/students");
 const teachers = require("../helpers/teachers");
 
@@ -41,7 +42,7 @@ router.post("/", async (req, res) => {
       statusString = req.body.StatusString;
       delete req.body.StatusString;
     }
-    const status = await students.getStatusPromise(statusString);
+    const status = await statuses.getStatusPromise(statusString);
     req.body.StatusID = status.StatusID;
   }
 
@@ -118,22 +119,20 @@ router.post("/", async (req, res) => {
   res.status(200).json(result);
 });
 
-
-router.patch('/:id', async (req, res) => {
+router.patch("/:id", async (req, res) => {
   if (req.body.NativeLanguageString) {
     try {
       const nativeLanguage = await students.getNativeLanguagePromise(
         req.body.NativeLanguageString
-      )
-      req.body.NativeLanguageID = nativeLanguage.NativeLanguageID
-      delete req.body.NativeLanguageString
-    
+      );
+      req.body.NativeLanguageID = nativeLanguage.NativeLanguageID;
+      delete req.body.NativeLanguageString;
     } catch (err) {
       return res.status(500).send({
         message: err.message,
-        type: 'UnknownError with NativeLanguage',
-        data: {}
-      })
+        type: "UnknownError with NativeLanguage",
+        data: {},
+      });
     }
   }
 
@@ -141,42 +140,40 @@ router.patch('/:id', async (req, res) => {
     try {
       const secondLanguage = await students.getNativeLanguagePromise(
         req.body.SecondLanguageString
-      )
-      req.body.SecondLanguageID = secondLanguage.NativeLanguageID
-      delete req.body.SecondLanguageString
-    
+      );
+      req.body.SecondLanguageID = secondLanguage.NativeLanguageID;
+      delete req.body.SecondLanguageString;
     } catch (err) {
       return res.status(500).send({
         message: err.message,
-        type: 'UnknownError with SecondLanguage',
-        data: {}
-      })
+        type: "UnknownError with SecondLanguage",
+        data: {},
+      });
     }
   }
 
-  const result = await teachers.patchTeacher(req.params.id, req.body)
+  const result = await teachers.patchTeacher(req.params.id, req.body);
 
   // handle error
   if (result.err) {
-    const err = result.err
+    const err = result.err;
     if (err instanceof NotFoundError) {
       res.status(409).send({
         message: err.message,
-        type: 'TeacherNotFound',
-        data: {}
-      })
+        type: "TeacherNotFound",
+        data: {},
+      });
     } else {
       res.status(500).send({
         message: err.message,
-        type: 'UnknownError. Database contraints may be violated',
-        data: {}
-      })
+        type: "UnknownError. Database contraints may be violated",
+        data: {},
+      });
     }
 
-    return
+    return;
   }
   res.status(200).json(result);
 });
-
 
 module.exports = router;


### PR DESCRIPTION
Moves two helpers:
- `getStatusPromise()` is moved from `helpers/students` -> `helpers/statuses`
- `getNativeLanguagePromise()` is moved from `helpers/students` -> `helpers/nativeLanguages`