### PR TITLE
Move function to disable input for second language proficiency to a watch method

### DIFF
--- a/frontend/src/pages/NewTeacher.vue
+++ b/frontend/src/pages/NewTeacher.vue
@@ -216,8 +216,7 @@ export default {
       this.uploadFile();
     },
 
-    SecondLanguage: function (newVal, oldVal) {
-      console.log(this.SecondLanguage);
+    SecondLanguage: function () {
       if (this.SecondLanguage != "") {
         this.isDisabled = false;
       }

--- a/frontend/src/pages/NewTeacher.vue
+++ b/frontend/src/pages/NewTeacher.vue
@@ -241,7 +241,7 @@ export default {
         Source: this.source,
         Email: this.Email,
         NativeLanguageString: this.selected.NativeLanguage,
-        ...(this.selected.SecondLanguage && {
+        ...(this.SecondLanguage && {
           SecondLanguageString: this.selected.SecondLanguage,
           LanguageProficiency: this.SecondLanguageProficiency,
         }),

--- a/frontend/src/pages/NewTeacher.vue
+++ b/frontend/src/pages/NewTeacher.vue
@@ -219,6 +219,9 @@ export default {
     SecondLanguage: function () {
       if (this.SecondLanguage != "") {
         this.isDisabled = false;
+      } else {
+        this.isDisabled = true;
+        this.SecondLanguageProficiency = "";
       }
     },
   },

--- a/frontend/src/pages/NewTeacher.vue
+++ b/frontend/src/pages/NewTeacher.vue
@@ -215,6 +215,13 @@ export default {
     file(val) {
       this.uploadFile();
     },
+
+    SecondLanguage: function (newVal, oldVal) {
+      console.log(this.SecondLanguage);
+      if (this.SecondLanguage != "") {
+        this.isDisabled = false;
+      }
+    },
   },
 
   async mounted() {
@@ -272,9 +279,6 @@ export default {
         );
       });
       this.checkLanguageExists = this.languageExists.length;
-      if (this.SecondLanguage != "") {
-        this.isDisabled = !this.isDisabled;
-      }
       if (this.SecondLanguage != "" && this.checkLanguageExists !== 1) {
         this.$buefy.notification.open({
           message:


### PR DESCRIPTION
<!-- Name of the Pull Request -->
# Fix bug where input for teacher's second language proficiency is not disabled if there are multiple attempts to edit Second Language 

<!-- JIRA Issue Number -->
User input for teacher's second language proficiency is supposed to be disabled if value for second language is null. The existing method for this is included within the `checkSecondLanguage` method. This is not optimal because it does not account for multiple changes to the Second Language field.

<!-- Please describe the changes in your Pull Request -->
## Moved the method to a `Watch` instead

This change implements essential features.

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Create a new Teacher
2. Second language proficiency should be disabled at the start
3. Type something in the Second Language field 
4. Second Language proficiency should be enabled 
5. Remove original input from Second Language and replace it with some other input 
6. Second Language proficiency should still be enabled 
