### PR TITLE
Issue 131 for filtering out dropped out teachers in suggestedTeachers

### DIFF
--- a/frontend/src/pages/Matching.vue
+++ b/frontend/src/pages/Matching.vue
@@ -360,7 +360,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(["unmatchedStudents", "teachers"]),
+    ...mapGetters(["unmatchedStudents", "teachers", "suggestedTeachers"]),
     ...mapState(["matchingSuccess"]),
     studentsData() {
       return this.unmatchedStudents
@@ -382,18 +382,20 @@ export default {
         );
     },
     teachersData() {
-      return this.teachers.map((teacher) => {
-        if (teacher.secondLanguage === null) {
-          teacher.secondLanguage = {};
-          teacher.secondLanguage.SecondLanguage = "";
+      return this.suggestedTeachers(this.selectedStudent.StudentID).map(
+        (teacher) => {
+          if (teacher.secondLanguage === null) {
+            teacher.secondLanguage = {};
+            teacher.secondLanguage.SecondLanguage = "";
+          }
+          return {
+            ...teacher,
+            NativeLanguage: `${teacher.nativeLanguage.NativeLanguage}`,
+            SecondLanguage: `${teacher.secondLanguage.NativeLanguage}`,
+            Status: `${teacher.status.Description}`,
+          };
         }
-        return {
-          ...teacher,
-          NativeLanguage: `${teacher.nativeLanguage.NativeLanguage}`,
-          SecondLanguage: `${teacher.secondLanguage.NativeLanguage}`,
-          Status: `${teacher.status.Description}`,
-        };
-      });
+      );
     },
     isDisabled() {
       return this.selectedStudent === null;

--- a/frontend/src/store/teachers.js
+++ b/frontend/src/store/teachers.js
@@ -136,14 +136,18 @@ export const teacherGetters = {
       // 2. Find their native language
       const studentNativeLanguage = student.NativeLanguageID;
 
-      // 3. Get unmatched teachers whose first or second language equals student's native language
+      // 3. Get unmatched teachers whose first or second language equals student's native language, and teacher is not dropped out
       const relevantTeachers = state.teachers.filter((teacher) => {
         const doesNativeLanguageMatch =
           teacher.NativeLanguageID === studentNativeLanguage;
         const doesSecondLanguageMatch =
           teacher.SecondLanguageID === studentNativeLanguage;
+        const isNotDroppedOut = teacher.status.Description !== "DROPPED OUT";
 
-        return doesNativeLanguageMatch || doesSecondLanguageMatch;
+        return (
+          isNotDroppedOut &&
+          (doesNativeLanguageMatch || doesSecondLanguageMatch)
+        );
       });
 
       // 4. Sort teachers by date joined AND status

--- a/frontend/src/store/teachers.js
+++ b/frontend/src/store/teachers.js
@@ -128,7 +128,7 @@ export const teacherGetters = {
     return (studentId) => {
       // 1. Find the student using the ID
       const student = state.students.find(
-        (student) => student.StudentID === studentId
+        (student) => parseInt(student.StudentID) === parseInt(studentId)
       );
       if (!student) {
         return [];


### PR DESCRIPTION
Fixes #131 

<!-- Name of the Pull Request -->
Filter out Dropped out teachers in suggestedTeachers (issue #131) and also enabled suggestedTeachers logic in Matching.vue

<!-- JIRA Issue Number -->
[IRRC-102](https://bootcamp-irrc.atlassian.net/browse/IRRC-102)

<!-- Please describe the changes in your Pull Request -->
added a filter to remove dropped out teachers and changed Matching.vue to show only suggestedTeachers when clicking on student

This change implements essential features.

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Try out suggestedTeachers logic in Matching.vue by clicking on student to ensure that the right logic is applied
2. Drop out a teacher
3. Try out the suggestedTeachers logic in matching.vue again and check that the dropped out teacher no longer shows up in the table of suggested teachers.
