### PR TITLE
[Matched Table] Update styling for "Confirmation" column

### DIFF
--- a/backend/src/helpers/matches.js
+++ b/backend/src/helpers/matches.js
@@ -1,13 +1,27 @@
-const db = require('../models/match')
+const db = require("../models/match");
 // const debug = require('debug')('app:students')
 
 exports.getAllMatches = async function () {
-  let query = db.Match.query().withGraphJoined('[student, teacher, studentStatusUpdate]')
-  
+  let query = db.Match.query().withGraphJoined(
+    "[student, teacher, studentStatusUpdate]"
+  );
+
   try {
-    const matches = await query.select()
-    return matches
+    const matches = await query.select();
+    return matches;
   } catch (err) {
-    return { err }
+    return { err };
   }
-}
+};
+
+exports.patchMatchStatus = async function (MatchID, MatchStatus) {
+  // Find entries based on MatchID
+  try {
+    let query = await db.Match.query()
+      .findById(MatchID)
+      .patch({ MatchStatus: MatchStatus });
+    return query;
+  } catch (err) {
+    return { err };
+  }
+};

--- a/backend/src/routes/matches.js
+++ b/backend/src/routes/matches.js
@@ -3,23 +3,22 @@ const router = express.Router();
 const db = require("../models/index");
 const statuses = require("../helpers/statuses");
 const statusUpdates = require("../helpers/statusUpdates.js");
-
-const matches = require('../helpers/matches')
+const matches = require("../helpers/matches");
 
 /* GET matches listing. */
 router.get("/", async (req, res) => {
   const my_matches = await matches.getAllMatches();
-  
+
   // handle error
   if (my_matches.err) {
     // console.log('entered result.err')
-    const err = my_matches.err
+    const err = my_matches.err;
     res.status(500).send({
       message: err.message,
-      type: 'UnknownError',
-      data: {}
-    })
-    return
+      type: "UnknownError",
+      data: {},
+    });
+    return;
   }
 
   res.json(my_matches);
@@ -131,6 +130,14 @@ router.post("/unmatch-student", async (req, res) => {
     nextStatusString: body.NextStatusString,
     res,
   });
+  return res.json(200, "successful");
+});
+
+// Patch status: Pass Match ID and MatchStatus
+router.patch("/:id", async (req, res) => {
+  // e.g. status/2/. full api URL is api/matches/2
+  const id = req.params.id;
+  await matches.patchMatchStatus(id, "Active");
   return res.json(200, "successful");
 });
 

--- a/backend/src/routes/matches.js
+++ b/backend/src/routes/matches.js
@@ -133,11 +133,13 @@ router.post("/unmatch-student", async (req, res) => {
   return res.json(200, "successful");
 });
 
-// Patch status: Pass Match ID and MatchStatus
-router.patch("/:id", async (req, res) => {
+// Patch status: Pass Match ID and MatchStatus.
+router.patch("/:id/:status?", async (req, res) => {
   // e.g. status/2/. full api URL is api/matches/2
+  // If no status passed, status will be active. Status is optional.
+  const status = req.params.status || "Active";
   const id = req.params.id;
-  await matches.patchMatchStatus(id, "Active");
+  await matches.patchMatchStatus(id, status);
   return res.json(200, "successful");
 });
 

--- a/frontend/src/components/MatchStatus.vue
+++ b/frontend/src/components/MatchStatus.vue
@@ -39,7 +39,6 @@ export default {
   props: ["status"],
   methods: {
     changeMatchStatus(value) {
-      console.log(value);
       // Emits value to the parent component and changes value
       this.$emit("change", value);
       this.value = "Active";

--- a/frontend/src/components/MatchStatus.vue
+++ b/frontend/src/components/MatchStatus.vue
@@ -1,0 +1,58 @@
+<template>
+  <div>
+    <!-- Display dropdown if MatchStatus is Pending. -->
+    <b-dropdown
+      v-if="status == 'Pending'"
+      :triggers="['hover']"
+      aria-role="list"
+    >
+      <template #trigger>
+        <b-button label="Pending" type="is-warning" icon-right="menu-down" />
+      </template>
+      <!-- Displays option to change status to Active -->
+      <b-dropdown-item :value="Active">{{ Active.label }}</b-dropdown-item>
+    </b-dropdown>
+    <!-- If MatchStatus is Active, show only the tag with no dropdown -->
+    <span v-else :class="['tag', Active.style]">
+      <li>{{ Active.label }}</li>
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Status",
+  data() {
+    return {
+      Pending: { label: "Pending", style: "is-warning" },
+      Active: { label: "Active", style: "is-success" },
+    };
+  },
+  props: ["status"],
+};
+</script>
+<style scoped>
+span.tag {
+  font-size: 1em;
+  justify-content: left;
+  padding-top: 25px;
+  padding-bottom: 25px;
+  width: 185px;
+}
+span.tag.is-info {
+  background-color: rgba(159, 207, 255, 0.15);
+  color: #00488f;
+}
+span.tag.is-success {
+  background-color: rgba(84, 140, 47, 0.15);
+  color: #255307;
+}
+span.tag.is-danger {
+  background-color: rgba(255, 166, 165, 0.15);
+  color: #be0e00;
+}
+span.tag.is-warning {
+  background-color: rgba(246, 174, 45, 0.08);
+  color: #f6ae2d;
+}
+</style>

--- a/frontend/src/components/MatchStatus.vue
+++ b/frontend/src/components/MatchStatus.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- Display dropdown if MatchStatus is Pending. -->
     <b-dropdown
-      v-if="status == 'Pending'"
+      v-if="value == 'Pending'"
       :triggers="['hover']"
       aria-role="list"
     >
@@ -10,7 +10,9 @@
         <b-button label="Pending" type="is-warning" icon-right="menu-down" />
       </template>
       <!-- Displays option to change status to Active -->
-      <b-dropdown-item :value="Active">{{ Active.label }}</b-dropdown-item>
+      <b-dropdown-item :value="Active" @click="changeMatchStatus('Active')">{{
+        Active.label
+      }}</b-dropdown-item>
     </b-dropdown>
     <!-- If MatchStatus is Active, show only the tag with no dropdown -->
     <span v-else :class="['tag', Active.style]">
@@ -24,20 +26,37 @@ export default {
   name: "Status",
   data() {
     return {
+      value: "",
       Pending: { label: "Pending", style: "is-warning" },
       Active: { label: "Active", style: "is-success" },
     };
   },
+  watch: {
+    status(value) {
+      this.value = value;
+    },
+  },
   props: ["status"],
+  methods: {
+    changeMatchStatus(value) {
+      console.log(value);
+      // Emits value to the parent component and changes value
+      this.$emit("change", value);
+      this.value = "Active";
+    },
+  },
+  mounted() {
+    this.value = this.status;
+  },
 };
 </script>
-<style scoped>
+<style scoped lang="scss">
 span.tag {
   font-size: 1em;
   justify-content: left;
   padding-top: 25px;
   padding-bottom: 25px;
-  width: 185px;
+  width: 100%;
 }
 span.tag.is-info {
   background-color: rgba(159, 207, 255, 0.15);
@@ -54,5 +73,22 @@ span.tag.is-danger {
 span.tag.is-warning {
   background-color: rgba(246, 174, 45, 0.08);
   color: #f6ae2d;
+}
+
+.dropdown-content {
+  // color:black !important
+  a {
+    color: black !important;
+  }
+  width: 100%;
+}
+.dropdown {
+  width: 100% !important;
+}
+.dropdown-trigger {
+  width: 100% !important;
+}
+button {
+  width: 100% !important;
 }
 </style>

--- a/frontend/src/components/Status.vue
+++ b/frontend/src/components/Status.vue
@@ -1,34 +1,39 @@
 <template>
-    <div> 
-        <span
-        :class="['tag', stat.style]"
-        > 
-        <li>{{stat.label}}</li>
-        </span>      
-    </div>
+  <div>
+    <span :class="['tag', stat.style]">
+      <li>{{ stat.label }}</li>
+      <slot></slot>
+    </span>
+    <!-- slot -->
+  </div>
 </template>
 
 <script>
 export default {
-    name: "Status",
-    data(){
-        return {
-            statuses: [ 
-            {"label": "Screening", "value": "SCREENING", "style": "is-info" },
-            {"label": "Unmatched", "value": "UNMATCHED", "style": "is-warning"},
-            {"label": "Matched", "value": "MATCHED", "style": "is-success"},
-            {"label": "Dropped Out", "value": "DROPPED OUT", "style": "is-danger"}
-            ]
+  name: "Status",
+  data() {
+    return {
+      statuses: [
+        { label: "Screening", value: "SCREENING", style: "is-info" },
+        { label: "Unmatched", value: "UNMATCHED", style: "is-warning" },
+        { label: "Matched", value: "MATCHED", style: "is-success" },
+        { label: "Dropped Out", value: "DROPPED OUT", style: "is-danger" },
+      ],
+    };
+  },
+  props: ["status"],
+  computed: {
+    stat() {
+      return (
+        this.statuses.find((item) => item.value === this.status) || {
+          label: "",
+          value: "",
+          style: "",
         }
+      );
     },
-    props: ["status"],
-    computed: {
-        stat() {
-            return this.statuses.find(item => item.value === this.status) || { label: "", value: "", style: "" }
-        } 
-
-    }
-}
+  },
+};
 </script>
 
 <style scoped>
@@ -55,5 +60,4 @@ span.tag.is-warning {
   background-color: rgba(246, 174, 45, 0.08);
   color: #f6ae2d;
 }
-
 </style>

--- a/frontend/src/pages/Matched.vue
+++ b/frontend/src/pages/Matched.vue
@@ -22,17 +22,6 @@
           selectable
         >
           <template v-for="column in columns">
-            <!-- <b-table-column
-              v-if="column.field == 'MatchStatus'"
-              :key="column.field"
-              v-bind="column"
-              sortable
-            >
-              <template v-slot="props">
-                <MatchStatus :status="props.row.MatchStatus" />
-                {{props.row.MatchStatus}}
-              </template>
-            </b-table-column> -->
             <b-table-column :key="column.field" v-bind="column" sortable>
               <template
                 v-if="column.searchable"
@@ -46,26 +35,10 @@
                 />
               </template>
               <template v-slot="props" v-if="column.select">
-                <!-- <b-field>
-                  <b-select
-                    :placeholder="column.select.placeholder"
-                    v-model="props.row[props.column.field]"
-                  >
-                    <option
-                      v-for="option in column.select.options"
-                      :key="option"
-                      :value="option"
-                    >
-                      {{ option }}
-                    </option>
-                  </b-select>
-                </b-field> -->
-
                 <MatchStatus
                   :status="props.row.MatchStatus"
                   @change="changeStatus(props.row)"
                 />
-                {{ props.row.MatchStatus }}
               </template>
               <template v-slot="props" v-else>
                 <span>
@@ -274,6 +247,7 @@ export default {
       "getAllMatches",
       "updateStudentStatus",
       "getDroppedReasons",
+      "patchMatchStatus",
     ]),
     clickUnmatch() {
       this.isComponentModalActive = true;
@@ -283,7 +257,9 @@ export default {
     },
     changeStatus(row) {
       const index = this.tableData.indexOf(row);
-      this.tableData[index].MatchStatus = "Active";
+      const matchID = parseInt(this.tableData[index].MatchID);
+      // this.tableData[index].MatchStatus = "Active";
+      this.patchMatchStatus(matchID);
     },
     showAddReason() {
       this.$buefy.dialog.prompt({

--- a/frontend/src/pages/Matched.vue
+++ b/frontend/src/pages/Matched.vue
@@ -22,7 +22,18 @@
           selectable
         >
           <template v-for="column in columns">
-            <b-table-column :key="column.field" v-bind="column" sortable>
+            <b-table-column
+              v-if="column.field == 'MatchStatus'"
+              :key="column.field"
+              v-bind="column"
+              sortable
+            >
+              <template v-slot="props">
+                <MatchStatus :status="props.row.MatchStatus" />
+                <!-- {{props.row.MatchStatus}} -->
+              </template>
+            </b-table-column>
+            <b-table-column v-else :key="column.field" v-bind="column" sortable>
               <template
                 v-if="column.searchable"
                 slot="searchable"
@@ -62,75 +73,72 @@
             </b-table-column>
           </template>
           <b-table-column label=" ">
-                <b-button>
-                  <b-icon icon="email-outline"></b-icon>
-                  <span>Resend</span>
-                </b-button>
+            <b-button>
+              <b-icon icon="email-outline"></b-icon>
+              <span>Resend</span>
+            </b-button>
           </b-table-column>
           <b-table-column label=" ">
-                <b-button @click="clickUnmatch()">
-                  <b-icon icon="account-multiple-check"></b-icon>
-                  <span>Unmatch</span>
-                </b-button>
+            <b-button @click="clickUnmatch()">
+              <b-icon icon="account-multiple-check"></b-icon>
+              <span>Unmatch</span>
+            </b-button>
           </b-table-column>
         </b-table>
 
         <!-- Unmatching modal  -->
 
-         <b-modal v-model="isComponentModalActive" :width="640" scroll="keep">
-            <div class="card">
-              <h2>Are you sure you want to unmatch?</h2>
-                <h4>Unmatching a pair would put students and teachers back to the matching process or dropped out section depending on the change in status</h4>
-                <h4>Student Name: {{selected.StudentName}}</h4>
-                  <b-field label="Status">
-                        <b-select
-                          placeholder="Select a status"
-                          v-model="selectedStudent.Status"
-                          :value="selectedStudent.Status"
-                          expanded
-                          :open-on-focus="true"
-                        >
-                            <option value="UNMATCHED">Unmatched</option>
-                            <option value="DROPPED OUT">Dropped out</option>
-                        </b-select>
-                  </b-field>
-                <!-- Dropped out reason --> 
-                  <b-field label="Reason">
-                    <b-autocomplete
-                      v-model="selectedStudent.Reason"
-                      :value="selectedStudent.Reason"
-                      field="Reason"
-                      ref="reasonComplete"
-                      :data="filteredReasonDataArray"
-                      placeholder="Select reason"
-                      :open-on-focus="true"
-                    >
-                      <template slot="header">
-                        <a @click="showAddReason">
-                          <span> Add new... </span>
-                        </a>
-                      </template>
-                    </b-autocomplete>
-                  </b-field>
-                <h4>Teacher Name: {{selected.TeacherName}}</h4>
-                  <span class="buttons">
-                    <b-button
-                    class="button field is-white"
-                    @click="close()"
-                    >
-                      <span>Cancel</span>
-                    </b-button>
+        <b-modal v-model="isComponentModalActive" :width="640" scroll="keep">
+          <div class="card">
+            <h2>Are you sure you want to unmatch?</h2>
+            <h4>
+              Unmatching a pair would put students and teachers back to the
+              matching process or dropped out section depending on the change in
+              status
+            </h4>
+            <h4>Student Name: {{ selected.StudentName }}</h4>
+            <b-field label="Status">
+              <b-select
+                placeholder="Select a status"
+                v-model="selectedStudent.Status"
+                :value="selectedStudent.Status"
+                expanded
+                :open-on-focus="true"
+              >
+                <option value="UNMATCHED">Unmatched</option>
+                <option value="DROPPED OUT">Dropped out</option>
+              </b-select>
+            </b-field>
+            <!-- Dropped out reason -->
+            <b-field label="Reason">
+              <b-autocomplete
+                v-model="selectedStudent.Reason"
+                :value="selectedStudent.Reason"
+                field="Reason"
+                ref="reasonComplete"
+                :data="filteredReasonDataArray"
+                placeholder="Select reason"
+                :open-on-focus="true"
+              >
+                <template slot="header">
+                  <a @click="showAddReason">
+                    <span> Add new... </span>
+                  </a>
+                </template>
+              </b-autocomplete>
+            </b-field>
+            <h4>Teacher Name: {{ selected.TeacherName }}</h4>
+            <span class="buttons">
+              <b-button class="button field is-white" @click="close()">
+                <span>Cancel</span>
+              </b-button>
 
-                    <b-button
-                    class="button field is-blue"
-                    @click="unmatch"
-                    >
-                      <span>Confirm</span>
-                    </b-button>
-                  </span>
-            </div>
+              <b-button class="button field is-blue" @click="unmatch">
+                <span>Confirm</span>
+              </b-button>
+            </span>
+          </div>
         </b-modal>
-
       </section>
     </div>
   </Page>
@@ -140,6 +148,7 @@
 import PageHeader from "../components/PageHeader.vue";
 import Page from "../components/Page.vue";
 import { mapGetters, mapActions, mapState } from "vuex";
+import MatchStatus from "../components/MatchStatus.vue";
 
 export default {
   data() {
@@ -196,6 +205,7 @@ export default {
   components: {
     Page,
     PageHeader,
+    MatchStatus,
   },
   computed: {
     ...mapGetters(["matches", "API_droppedReason"]),
@@ -211,31 +221,56 @@ export default {
     },
     tableData() {
       return this.matches.map((match) => {
-        let DateMatched, ConfirmedDate, LastEmailDate = "";
-        DateMatched = new Date(match.studentStatusUpdate.updated_at).toLocaleDateString("en-US",{day: "2-digit", month: "short", year: "numeric",}).replace(",", " ");
-        ConfirmedDate = new Date(match.ConfirmedDate).toLocaleDateString("en-US",{day: "2-digit", month: "short", year: "numeric",}).replace(",", " ");
-        LastEmailDate = new Date(match.LastEmailDate).toLocaleDateString("en-US",{day: "2-digit", month: "short", year: "numeric",}).replace(",", " ");
+        let DateMatched,
+          ConfirmedDate,
+          LastEmailDate = "";
+        DateMatched = new Date(match.studentStatusUpdate.updated_at)
+          .toLocaleDateString("en-US", {
+            day: "2-digit",
+            month: "short",
+            year: "numeric",
+          })
+          .replace(",", " ");
+        ConfirmedDate = new Date(match.ConfirmedDate)
+          .toLocaleDateString("en-US", {
+            day: "2-digit",
+            month: "short",
+            year: "numeric",
+          })
+          .replace(",", " ");
+        LastEmailDate = new Date(match.LastEmailDate)
+          .toLocaleDateString("en-US", {
+            day: "2-digit",
+            month: "short",
+            year: "numeric",
+          })
+          .replace(",", " ");
 
         return {
-            DateMatched: DateMatched,
-            TeacherName: `${match.teacher.FullName}`,
-            TeacherID: `${match.teacher.TeacherID}`,
-            StudentName: `${match.student.FullName}`,
-            StudentID: `${match.student.StudentID}`,
-            MatchStatus: `${match.MatchStatus}`,
-            ConfirmedDate: ConfirmedDate,
-            LastEmailDate: LastEmailDate,
-
-        }
+          DateMatched: DateMatched,
+          TeacherName: `${match.teacher.FullName}`,
+          TeacherID: `${match.teacher.TeacherID}`,
+          StudentName: `${match.student.FullName}`,
+          StudentID: `${match.student.StudentID}`,
+          MatchStatus: `${match.MatchStatus}`,
+          ConfirmedDate: ConfirmedDate,
+          LastEmailDate: LastEmailDate,
+        };
       });
     },
   },
   methods: {
-    ...mapActions(['patchScreeningStudents', 'getAllStudents', 'getAllMatches', 'updateStudentStatus', 'getDroppedReasons']),
-    clickUnmatch(){
+    ...mapActions([
+      "patchScreeningStudents",
+      "getAllStudents",
+      "getAllMatches",
+      "updateStudentStatus",
+      "getDroppedReasons",
+    ]),
+    clickUnmatch() {
       this.isComponentModalActive = true;
     },
-    close(){
+    close() {
       this.isComponentModalActive = false;
     },
     showAddReason() {
@@ -256,7 +291,7 @@ export default {
             this.addDroppedReason(this.selectedStudent.Reason);
           }
         },
-      })
+      });
     },
     unmatch() {
       this.updateStudentStatus({
@@ -266,17 +301,17 @@ export default {
         updatedBy: "IRRCAdmin",
         reason: "DROPPED_" + this.selectedStudent.Reason,
       }).then(() => {
-        this.isComponentModalActive = false
-        this.getAllStudents().then(()=> this.$router.go(0))
+        this.isComponentModalActive = false;
+        this.getAllStudents().then(() => this.$router.go(0));
       });
-    }
+    },
   },
   mounted() {
-      this.getAllStudents();
-      this.getAllMatches();
-      this.getDroppedReasons();
+    this.getAllStudents();
+    this.getAllMatches();
+    this.getDroppedReasons();
   },
-}
+};
 </script>
 
 <style>
@@ -358,15 +393,12 @@ button.is-blue {
   color: white !important;
 }
 
-
 .header {
   background: none !important;
 }
-
 
 .card {
   padding: 30px;
   padding-bottom: 40px;
 }
-
 </style>

--- a/frontend/src/pages/Matched.vue
+++ b/frontend/src/pages/Matched.vue
@@ -256,8 +256,7 @@ export default {
       this.isComponentModalActive = false;
     },
     changeStatus(row) {
-      const index = this.tableData.indexOf(row);
-      const matchID = parseInt(this.tableData[index].MatchID);
+      const matchID = parseInt(row.MatchID);
       // this.tableData[index].MatchStatus = "Active";
       this.patchMatchStatus(matchID);
     },

--- a/frontend/src/pages/Matched.vue
+++ b/frontend/src/pages/Matched.vue
@@ -22,7 +22,7 @@
           selectable
         >
           <template v-for="column in columns">
-            <b-table-column
+            <!-- <b-table-column
               v-if="column.field == 'MatchStatus'"
               :key="column.field"
               v-bind="column"
@@ -30,10 +30,10 @@
             >
               <template v-slot="props">
                 <MatchStatus :status="props.row.MatchStatus" />
-                <!-- {{props.row.MatchStatus}} -->
+                {{props.row.MatchStatus}}
               </template>
-            </b-table-column>
-            <b-table-column v-else :key="column.field" v-bind="column" sortable>
+            </b-table-column> -->
+            <b-table-column :key="column.field" v-bind="column" sortable>
               <template
                 v-if="column.searchable"
                 slot="searchable"
@@ -46,7 +46,7 @@
                 />
               </template>
               <template v-slot="props" v-if="column.select">
-                <b-field>
+                <!-- <b-field>
                   <b-select
                     :placeholder="column.select.placeholder"
                     v-model="props.row[props.column.field]"
@@ -59,7 +59,13 @@
                       {{ option }}
                     </option>
                   </b-select>
-                </b-field>
+                </b-field> -->
+
+                <MatchStatus
+                  :status="props.row.MatchStatus"
+                  @change="changeStatus(props.row)"
+                />
+                {{ props.row.MatchStatus }}
               </template>
               <template v-slot="props" v-else>
                 <span>
@@ -188,6 +194,7 @@ export default {
           field: "MatchStatus",
           label: "Confirmation",
           searchable: true,
+          select: true,
         },
         {
           field: "ConfirmedDate",
@@ -255,6 +262,7 @@ export default {
           MatchStatus: `${match.MatchStatus}`,
           ConfirmedDate: ConfirmedDate,
           LastEmailDate: LastEmailDate,
+          MatchID: `${match.MatchID}`,
         };
       });
     },
@@ -272,6 +280,10 @@ export default {
     },
     close() {
       this.isComponentModalActive = false;
+    },
+    changeStatus(row) {
+      const index = this.tableData.indexOf(row);
+      this.tableData[index].MatchStatus = "Active";
     },
     showAddReason() {
       this.$buefy.dialog.prompt({

--- a/frontend/src/store/matches.js
+++ b/frontend/src/store/matches.js
@@ -1,26 +1,31 @@
 const MUTATIONS = Object.freeze({
-    SET_MATCHES: 'SET_MATCHES',
-  })
+  SET_MATCHES: "SET_MATCHES",
+});
 
-
-export const matchesState = {matches: []} 
+export const matchesState = { matches: [] };
 export const matchesActions = {
-    async getAllMatches({commit}){
-        const response = await fetch("/api/matches")
-        const matchesData = await response.json()
-        commit(MUTATIONS.SET_MATCHES, matchesData)        
-    },
-}
+  async getAllMatches({ commit }) {
+    const response = await fetch("/api/matches");
+    const matchesData = await response.json();
+    commit(MUTATIONS.SET_MATCHES, matchesData);
+  },
+  async patchMatchStatus({ dispatch }, id) {
+    const response = await fetch(`/api/matches/${id}`, { method: "PATCH" });
+    await response.json();
+    if (response.status == 200) {
+      dispatch("getAllMatches");
+    }
+  },
+};
 
 export const matchesMutations = {
-    [MUTATIONS.SET_MATCHES](state, matches){
-        state.matches = matches;
-    },
-}
+  [MUTATIONS.SET_MATCHES](state, matches) {
+    state.matches = matches;
+  },
+};
 
 export const matchesGetters = {
-    matches(state) {
-        return state.matches
-    }
-} 
-
+  matches(state) {
+    return state.matches;
+  },
+};


### PR DESCRIPTION
<!-- Name of the Pull Request -->
# Updating styling for "Confirmation" column

<!-- JIRA Issue Number -->
Addresses issue #129 

<!-- Please describe the changes in your Pull Request -->
MatchStatus should appear as a dropdown in the "Confirmation" column if MatchStatus == Pending.
Otherwise (MatchStatus == Active) and will display as a green tag. 

When "Active" is selected from the dropdown for a match that is currently Pending, MatchStatus in the backend should also be updated. 

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Match a student and teacher 
2. Check Matched table if it appears as Pending, and if Pending is a dropdown with an option "Active"
3. Click on the "Active" option.
4. The match's confirmation status should appear as "Active" in table data. When clicking to sort, statuses should be sorted according to Active and Pending 
5. Check api/matches — MatchStatus for that match should now be "Active" instead of "Pending". 
