### PR TITLE
Force correct reload on Matching.vue and Screening.vue pages

### DIFF
--- a/frontend/src/pages/Matching.vue
+++ b/frontend/src/pages/Matching.vue
@@ -443,9 +443,14 @@ export default {
               StudentID: parseInt(item.StudentID),
               StudentFullName: item.StudentFullName,
               UpdatedBy: "IRRCAdmin",
+              LastEmailDate: new Date(),
+              MatchStatus: "Pending",
+              ConfirmedDate: new Date(),
             };
           });
-          this.patchUnmatchedStudents(patchMatchesData);
+          this.patchUnmatchedStudents(patchMatchesData).then(() =>
+            this.$router.go(0)
+          );
         },
       });
     },
@@ -462,13 +467,14 @@ export default {
               StudentID: parseInt(item.StudentID),
               StudentFullName: item.StudentFullName,
               UpdatedBy: "IRRCAdmin",
-              LastEmailDate: new Date("Feburary 17, 2021 03:24:00"),
+              LastEmailDate: new Date(),
               MatchStatus: "Pending",
-              ConfirmedDate: new Date("Feburary 21, 2021 03:24:00"),
+              ConfirmedDate: new Date(),
             };
           });
-          this.patchUnmatchedStudents(patchMatchesData);
-          this.$router.go(0);
+          this.patchUnmatchedStudents(patchMatchesData).then(() =>
+            this.$router.go(0)
+          );
         },
       });
     },

--- a/frontend/src/pages/Screening.vue
+++ b/frontend/src/pages/Screening.vue
@@ -17,7 +17,7 @@
             @click="cardModal()"
             :disabled="!checkedRows.length"
           >
-            <span>Matched selected</span>: {{ checkedRows.length }}
+            <span>Ready to match</span>: {{ checkedRows.length }}
           </button>
           <b-button class="button field is-blue">
             <b-icon icon="download"></b-icon>
@@ -149,7 +149,7 @@ export default {
   },
   computed: {
     ...mapGetters(["screeningStudents"]),
-    ...mapState(['screeningSuccess']),
+    ...mapState(["screeningSuccess"]),
     tableData() {
       return this.screeningStudents.map((student) => {
         return {
@@ -162,33 +162,36 @@ export default {
   watch: {
     screeningSuccess() {
       if (this.screeningSuccess) {
-        this.getAllStudents()
+        this.getAllStudents();
       }
-    }
+    },
   },
   methods: {
-    ...mapActions(['patchScreeningStudents', 'getAllStudents']),
+    ...mapActions(["patchScreeningStudents", "getAllStudents"]),
     cardModal() {
       this.$buefy.dialog.confirm({
-        type: 'is-blue',
-        message: '<b> Students ready to be matched?</b> <br> Confirming will add these students to the page for them to be matched with teachers.',
+        type: "is-blue",
+        message:
+          "<b> Students ready to be matched?</b> <br> Confirming will add these students to the page for them to be matched with teachers.",
         onConfirm: () => {
-          const patchStudentsData = this.checkedRows.map(item => {
+          const patchStudentsData = this.checkedRows.map((item) => {
             return {
               StudentID: item.StudentID,
               EnglishProficiency: item.EnglishProficiency,
               // TODO: Make dynamic with account management
-              UpdatedBy: "IRRCAdmin"
-            }
-          })
-          this.patchScreeningStudents(patchStudentsData)
-        }
-      }) 
+              UpdatedBy: "IRRCAdmin",
+            };
+          });
+          this.patchScreeningStudents(patchStudentsData).then(() =>
+            this.$router.go(0)
+          );
+        },
+      });
     },
     goToStudent() {
-      this.$router.push({ path: `/students/${this.selected.StudentID}` })
-    }
-  }
+      this.$router.push({ path: `/students/${this.selected.StudentID}` });
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
Previously, "Confirm all" on the Matching table was reloading too early.

To test: 
1. create a student and teacher
2. go through the screening flow and make sure the Screening table refreshes after submission. 
3. check that the screened student appears in the Matching table.
4. go through the matching flow and make sure the Matching table refreshes after submission. 
5. check that the match appears in the Matched table.