### PR TITLE
add pagination to Teachers + update helpers for statuses and nativeLanguages

### DIFF
--- a/backend/src/helpers/nativeLanguages.js
+++ b/backend/src/helpers/nativeLanguages.js
@@ -1,6 +1,7 @@
 const db = require("../models/nativeLanguage");
+const { get } = require("../routes/teachers");
 
-exports.addNativeLanguage = async function (nativeLanguage) {
+const addNativeLanguage = async function (nativeLanguage) {
   try {
     const response = await db.NativeLanguage.query().insert(nativeLanguage);
     return response;
@@ -8,8 +9,9 @@ exports.addNativeLanguage = async function (nativeLanguage) {
     return { err };
   }
 };
+exports.addNativeLanguage = addNativeLanguage;
 
-exports.getNativeLanguageByString = async function (nativeLanguageString) {
+const getNativeLanguageByString = async function (nativeLanguageString) {
   try {
     const response = await db.NativeLanguage.query().findOne(
       "NativeLanguage",
@@ -21,16 +23,17 @@ exports.getNativeLanguageByString = async function (nativeLanguageString) {
     return { err };
   }
 };
+exports.getNativeLanguageByString = getNativeLanguageByString;
 
 exports.getNativeLanguagePromise = async function (nativeLanguageString) {
   if (nativeLanguageString != null) {
-    const nativeLanguageResponse = await nativeLanguages.getNativeLanguageByString(
+    const nativeLanguageResponse = await getNativeLanguageByString(
       nativeLanguageString
     );
     if (nativeLanguageResponse && !nativeLanguageResponse.err) {
       return nativeLanguageResponse;
     } else if (!nativeLanguageResponse) {
-      const newNativeLanguage = await nativeLanguages.addNativeLanguage({
+      const newNativeLanguage = await addNativeLanguage({
         NativeLanguage: nativeLanguageString.toUpperCase(),
       });
       return newNativeLanguage;

--- a/backend/src/helpers/statuses.js
+++ b/backend/src/helpers/statuses.js
@@ -1,6 +1,6 @@
 const db = require("../models/status");
 
-exports.getStatusByStatusString = async function (statusString) {
+const getStatusByStatusString = async function (statusString) {
   try {
     const response = await db.Status.query().findOne(
       "Description",
@@ -12,13 +12,14 @@ exports.getStatusByStatusString = async function (statusString) {
     return { err };
   }
 };
+exports.getStatusByStatusString = getStatusByStatusString;
 
 exports.getStatusPromise = async function (statusString) {
   if (statusString != null) {
     // If request contains StatusString, return corresponding StatusID
-    return statuses.getStatusByStatusString(statusString);
+    return getStatusByStatusString(statusString);
   } else {
     // If StatusID and StatusString are both not provided, default to 'SCREENING' StatusID
-    return statuses.getStatusByStatusString("SCREENING");
+    return getStatusByStatusString("SCREENING");
   }
 };

--- a/backend/src/routes/statusUpdates.js
+++ b/backend/src/routes/statusUpdates.js
@@ -66,7 +66,6 @@ router.post("/", async (req, res) => {
       type: err.type,
       data: err.data,
     });
-    console.log(err);
     return;
   }
 

--- a/backend/src/routes/teachers.js
+++ b/backend/src/routes/teachers.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const router = express.Router();
-
 const statuses = require("../helpers/statuses");
 const nativeLanguages = require("../helpers/nativeLanguages");
 const teachers = require("../helpers/teachers");
@@ -60,7 +59,7 @@ router.post("/", async (req, res) => {
       req.body.NativeLanguageID = nativeLanguage.NativeLanguageID;
     }
   } catch (err) {
-    res.status(400).send({
+    return res.status(400).send({
       message: err.message,
       type: "MissingParams",
       data: {},
@@ -82,7 +81,7 @@ router.post("/", async (req, res) => {
       }
     }
   } catch (err) {
-    res.status(400).send({
+    return res.status(400).send({
       message: err.message,
       type: "MissingParams",
       data: {},
@@ -90,12 +89,13 @@ router.post("/", async (req, res) => {
   }
 
   const result = await teachers.addTeacher(req.body);
-
+  console.log(result.err);
+  console.log(result);
   // handle error
   if (result.err) {
     const err = result.err;
     if (err instanceof UniqueViolationError) {
-      res.status(409).send({
+      return res.status(409).send({
         message: err.message,
         type: "UniqueViolation",
         data: {
@@ -105,17 +105,15 @@ router.post("/", async (req, res) => {
         },
       });
     } else {
-      res.status(500).send({
+      return res.status(500).send({
         message: err.message,
         type: "UnknownError",
         data: {},
       });
     }
-
-    return;
   }
 
-  res.status(200).json(result);
+  return res.status(200).json(result);
 });
 
 router.patch("/:id", async (req, res) => {

--- a/frontend/src/pages/Teachers.vue
+++ b/frontend/src/pages/Teachers.vue
@@ -9,6 +9,9 @@
         :data="teachersData"
         :selected.sync="selected"
         @dblclick="goToTeacher"
+        :paginated="isPaginated"
+        :pagination-position="bottom"
+        :per-page="perPage"
       >
         <b-table-column
           field="created_at"
@@ -140,6 +143,8 @@ export default {
   data() {
     return {
       selected: {},
+      isPaginated: true,
+      perPage: 10,
     };
   },
   methods: {
@@ -165,6 +170,12 @@ body {
 .Title {
   padding-bottom: 20px;
   vertical-align: bottom !important;
+}
+ul.pagination-list {
+  margin: 0 auto;
+}
+.content ul {
+  list-style: none;
 }
 span.tag {
   font-size: 1em;


### PR DESCRIPTION

<!-- Name of the Pull Request -->
# Add paginations to Teachers.Vue + update helpers 

addresses #127 

<!-- Please describe the changes in your Pull Request -->
Adds pagination to teachers table (10 teachers per page). 
Fixes helpers for nativelanguages and statuses by declaring variables (so they can be used locally), then exporting it. 
If these changes are not made, it is not possible to create new teachers/students 

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Use Postman 
2. Create a new Teacher/Students (sample request body: {"PhoneNumber":"93844322","FullName":"arjay","Source":"","Email":"arjay@gmail.com","NativeLanguageString":"CHINESE","SecondLanguageString":"TAMIL","LanguageProficiency":"Fluent","EnglishProficiency":"Intermediate","Notes":"","StatusString":"UNMATCHED"})
3. See if backend (api/teachers or api/students) is updated 