### PR TITLE
Default student FirstName to FullName when rolling back migration

### DIFF
--- a/backend/migrations/20201107134701_remove_firstName_lastName_from_students.js
+++ b/backend/migrations/20201107134701_remove_firstName_lastName_from_students.js
@@ -1,17 +1,20 @@
-const { tableStudents } = require('../src/models/student')
+const { tableStudents } = require("../src/models/student");
 
-exports.up = function(knex, Promise) {
-    return knex.schema.table(tableStudents, (table) => {
-        table.dropUnique(['PhoneNumber', 'FirstName', 'LastName']);
-        table.dropColumn('FirstName');
-        table.dropColumn('LastName');
-    });
+exports.up = function (knex, Promise) {
+  return knex.schema.table(tableStudents, (table) => {
+    table.dropUnique(["PhoneNumber", "FirstName", "LastName"]);
+    table.dropColumn("FirstName");
+    table.dropColumn("LastName");
+  });
 };
 
-exports.down = function(knex, Promise) {
-    return knex.schema.table(tableStudents, (table) => {
-        table.text('FirstName').notNullable().defaultTo('')
-        table.text('LastName').notNullable().defaultTo('')
-        table.unique(['PhoneNumber', 'FirstName', 'LastName'])
-    });
+exports.down = async function (knex, Promise) {
+  await knex.schema.table(tableStudents, (table) => {
+    table.text("FirstName").notNullable().defaultTo("");
+    table.text("LastName").notNullable().defaultTo("");
+  });
+  await knex.raw(`UPDATE "students" SET "FirstName" = "FullName"`);
+  await knex.schema.table(tableStudents, (table) => {
+    table.unique(["PhoneNumber", "FirstName", "LastName"]);
+  });
 };


### PR DESCRIPTION
This avoids violating the unique constraint on `("PhoneNumber", "FirstName", "LastName")` for students with the same phone number when rolling back the student migration.

To test:
1. Create multiple new students with the same phone number
2. Try running `npm run db:migrate:rollback && npm run db:migrate`