### PR TITLE
Clickthrough to individual profile from 'View Profile' popup in New Student/Teacher

### DIFF
--- a/frontend/src/pages/NewStudent.vue
+++ b/frontend/src/pages/NewStudent.vue
@@ -177,17 +177,13 @@ export default {
         StatusString: "SCREENING",
       })
         .then((response) => response.json())
-        .then((data) => {
-          this.$buefy.snackbar.open({
-            message: "New Student Added",
-            type: "is-success",
-            position: "is-top",
-            actionText: "View Profile",
-            indefinite: true,
-            onAction: () => {
-              this.$router.push({ path: `/students/${data.StudentID}` });
-            },
-          });
+        .then((student) => {
+            this.$buefy.toast.open({
+              message: `Student saved. <u><a href="/students/${student.StudentID}">View profile</a></u>!`,
+              duration: 3000,
+              type: "is-success",
+              position: "is-top",
+            });
           this.getNativeLanguages();
         })
         .catch((error) => {

--- a/frontend/src/pages/NewTeacher.vue
+++ b/frontend/src/pages/NewTeacher.vue
@@ -252,17 +252,19 @@ export default {
 
       this.createTeacher(teacherData).then((response) => {
         if (response.status < 400) {
-          this.$buefy.notification.open({
-            message: "New teacher added. <u>View profile</u>!",
-            duration: 3000,
-            type: "is-success",
-            position: "is-top",
+          response.json().then((teacher) => {
+            this.$buefy.toast.open({
+              message: `Teacher saved. <u><a href="/teachers/${teacher.TeacherID}">View profile</a></u>!`,
+              duration: 3000,
+              type: "is-success",
+              position: "is-top",
+            });
+            // refreshes state
+            this.getNativeLanguages();
+            setTimeout(() => {
+              this.$router.push({ path: `/teachers` });
+            }, 5000);
           });
-          // refreshes state
-          this.getNativeLanguages();
-          setTimeout(() => {
-            this.$router.push({ path: `/teachers` });
-          }, 5000);
         } else {
           this.$buefy.notification.open({
             message: "Something went wrong. Please try again.",


### PR DESCRIPTION
Closes #113. This is based on #151 which is currently unmerged.

Enables clickthrough from "View Profile" popup to the individual profile from New Student/Teacher forms. Similar to #110 which made this change for the Edit Student/Teacher forms.

To review this diff without being distracted by formatting changes, `Ctrl + F` "View profile".

To test:
1. Make a new student (teacher)
2. Wait for the popup with a "View Profile" link
3. Click on "View Profile" and check that you are redirected to the newly created student (teacher)