### PR TITLE
Handle null secondLanguage in TeacherProfile.vue

### DIFF
--- a/frontend/src/components/modals/ModalDroppedOut.vue
+++ b/frontend/src/components/modals/ModalDroppedOut.vue
@@ -42,10 +42,10 @@ export default {
   name: "ModalDroppedOut",
   props: {
     studentID: {
-      type: String,
+      type: Number,
     },
     teacherID: {
-      type: String,
+      type: Number,
     },
     previousStatusString: {
       type: String,
@@ -87,15 +87,13 @@ export default {
       "addDroppedReason",
     ]),
     toDroppedOut() {
-      const studentID = parseInt(this.studentID);
-      const teacherID = parseInt(this.teacherID);
       const previousStatusString = this.previousStatusString;
       const nextStatusString = "DROPPED OUT";
       const updatedBy = "IRRCAdmin";
 
       if (this.isTeacher) {
         this.updateTeacherStatus({
-          teacherID: teacherID,
+          teacherID: this.teacherID,
           previousStatusString: previousStatusString,
           nextStatusString: nextStatusString,
           updatedBy: updatedBy,
@@ -104,7 +102,7 @@ export default {
         this.$emit("close");
       } else {
         this.updateStudentStatus({
-          studentID: studentID,
+          studentID: this.studentID,
           previousStatusString: previousStatusString,
           nextStatusString: nextStatusString,
           updatedBy: updatedBy,

--- a/frontend/src/components/statusCards/StatusCardDroppedOut.vue
+++ b/frontend/src/components/statusCards/StatusCardDroppedOut.vue
@@ -51,16 +51,16 @@ export default {
       type: Boolean,
     },
     studentID: {
-      type: String,
+      type: Number,
     },
     teacherID: {
-      type: String,
+      type: Number,
     },
   },
   methods: {
     ...mapActions(["updateStudentStatus", "updateTeacherStatus"]),
     droppedOutToScreening() {
-      const studentID = parseInt(this.studentID);
+      const studentID = this.studentID;
       const previousStatusString = "DROPPED OUT";
       const nextStatusString = "SCREENING";
       const updatedBy = "IRRCAdmin";
@@ -73,7 +73,7 @@ export default {
       });
     },
     droppedOutToMatching() {
-      const teacherID = parseInt(this.teacherID);
+      const teacherID = this.teacherID;
       const previousStatusString = "DROPPED OUT";
       const nextStatusString = "UNMATCHED";
       const updatedBy = "IRRCAdmin";

--- a/frontend/src/components/statusCards/StatusCardMatched.vue
+++ b/frontend/src/components/statusCards/StatusCardMatched.vue
@@ -52,10 +52,10 @@ export default {
       default: "No Student Assigned",
     },
     studentID: {
-      type: String,
+      type: Number,
     },
     teacherID: {
-      type: String,
+      type: Number,
     },
     isTeacher: {
       type: Boolean,
@@ -95,12 +95,11 @@ export default {
       });
     },
     matchedToUnmatched() {
-      const teacherID = parseInt(this.teacherID);
       const previousStatusString = "MATCHED";
       const nextStatusString = "UNMATCHED";
       const updatedBy = "IRRCAdmin";
       this.updateTeacherStatus({
-        teacherID: teacherID,
+        teacherID: this.teacherID,
         previousStatusString: previousStatusString,
         nextStatusString: nextStatusString,
         updatedBy: updatedBy,

--- a/frontend/src/components/statusCards/StatusCardScreening.vue
+++ b/frontend/src/components/statusCards/StatusCardScreening.vue
@@ -33,7 +33,7 @@ export default {
   },
   props: {
     studentID: {
-      type: String,
+      type: Number,
     },
     englishProficiency: {
       type: String,
@@ -43,13 +43,12 @@ export default {
     ...mapActions(["updateStudentStatus", "updateStudentEnglishProficiency"]),
     screeningToUnmatched() {
       // Update student status
-      const studentID = parseInt(this.studentID);
       const previousStatusString = "SCREENING";
       const nextStatusString = "UNMATCHED";
       const updatedBy = "IRRCAdmin";
 
       this.updateStudentStatus({
-        studentID: studentID,
+        studentID: this.studentID,
         previousStatusString: previousStatusString,
         nextStatusString: nextStatusString,
         updatedBy: updatedBy,
@@ -57,7 +56,7 @@ export default {
 
       // Update English proficiency
       this.updateStudentEnglishProficiency({
-        studentID: studentID,
+        studentID: this.studentID,
         englishProficiency: this.englishProficiency,
       });
     },

--- a/frontend/src/components/statusCards/StatusCardUnmatched.vue
+++ b/frontend/src/components/statusCards/StatusCardUnmatched.vue
@@ -40,10 +40,10 @@ export default {
   },
   props: {
     studentID: {
-      type: String,
+      type: Number,
     },
     teacherID: {
-      type: String,
+      type: Number,
     },
     isTeacher: {
       type: Boolean,

--- a/frontend/src/pages/StudentProfile.vue
+++ b/frontend/src/pages/StudentProfile.vue
@@ -76,7 +76,7 @@ export default {
     studentData() {
       const data = this.student;
       const studentObject = {
-        StudentID: data.StudentID.toString(),
+        StudentID: data.StudentID,
         PhoneNumber: data.PhoneNumber,
         FullName: data.FullName,
         Source: data.Source,

--- a/frontend/src/pages/Students.vue
+++ b/frontend/src/pages/Students.vue
@@ -129,7 +129,6 @@ export default {
       sortIconSize: "is-small",
       sortDirection: "asc",
       isPaginated: true,
-      paginationPosition: "bottom",
       currentPage: 1,
       perPage: 10,
     };

--- a/frontend/src/pages/TeacherProfile.vue
+++ b/frontend/src/pages/TeacherProfile.vue
@@ -97,35 +97,34 @@ export default {
         EnglishProficiency: data.EnglishProficiency,
         LanguageProficiency: data.LanguageProficiency,
       };
-      return teacherObject
+      return teacherObject;
     },
-    teacherHistory(){
-      const teacherHistory = this.teacher.statusUpdates.map(update => {
-      if (update.reason == null) {
-        update.reason = {
-          Reason: "_"
+    teacherHistory() {
+      const teacherHistory = this.teacher.statusUpdates.map((update) => {
+        if (update.reason == null) {
+          update.reason = {
+            Reason: "_",
+          };
         }
-      } 
-      return {
-        id: update.StatusUpdateID,
-        date: new Date(update.created_at).toDateString(),
-        description: update.nextStatus.Description,
-        status: update.nextStatus.StatusID,
-        reason: update.reason.Reason.split("_")[1],
-      };
-    });
-    return teacherHistory.sort((a, b) => b.id - a.id)
+        return {
+          id: update.StatusUpdateID,
+          date: new Date(update.created_at).toDateString(),
+          description: update.nextStatus.Description,
+          status: update.nextStatus.StatusID,
+          reason: update.reason.Reason.split("_")[1],
+        };
+      });
+      return teacherHistory.sort((a, b) => b.id - a.id);
     },
-    latestReason(){
-      return this.teacherHistory[0].reason
+    latestReason() {
+      return this.teacherHistory[0].reason;
     },
-    teacher(){
-      const id = this.$route.params.id
-      const data = this.getTeacherByTeacherId(id)
-      return data 
-    }
+    teacher() {
+      const id = this.$route.params.id;
+      const data = this.getTeacherByTeacherId(id);
+      return data;
+    },
   },
-  
 };
 </script>
 

--- a/frontend/src/pages/TeacherProfile.vue
+++ b/frontend/src/pages/TeacherProfile.vue
@@ -76,14 +76,19 @@ export default {
   },
   data: function () {
     return {
-      teacherID: ""
+      teacherID: "",
     };
   },
   computed: {
     ...mapGetters(["getTeacherByTeacherId"]),
-    teacherData(){
-      const data = this.teacher
-    //console.log(data);
+    teacherData() {
+      const data = this.teacher;
+      if (!data.secondLanguage) {
+        data.secondLanguage = {
+          NativeLanguageID: "",
+          NativeLanguage: "",
+        };
+      }
       const teacherObject = {
         TeacherID: data.TeacherID,
         PhoneNumber: data.PhoneNumber,

--- a/frontend/src/pages/Teachers.vue
+++ b/frontend/src/pages/Teachers.vue
@@ -10,7 +10,6 @@
         :selected.sync="selected"
         @dblclick="goToTeacher"
         :paginated="isPaginated"
-        :pagination-position="bottom"
         :per-page="perPage"
       >
         <b-table-column

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -15,30 +15,30 @@ import {
 import {
   screeningActions,
   screeningState,
-  screeningMutations
+  screeningMutations,
 } from "./store/screening.js";
 import {
   studentActions,
   studentGetters,
   studentMutations,
-  studentState
+  studentState,
 } from "./store/students.js";
 import {
-  matchingActions, 
-  matchingState, 
-  matchingMutations
+  matchingActions,
+  matchingState,
+  matchingMutations,
 } from "./store/matching.js";
 import {
   reasonActions,
   reasonGetters,
   reasonMutations,
-  reasonState
+  reasonState,
 } from "./store/reasons.js";
 import {
   matchesGetters,
   matchesActions,
   matchesMutations,
-  matchesState
+  matchesState,
 } from "./store/matches.js";
 
 Vue.use(Vuex);
@@ -76,7 +76,7 @@ export default new Vuex.Store({
     ...screeningActions,
     ...matchingActions,
     ...reasonActions,
-    ...matchesActions
+    ...matchesActions,
   },
   getters: {
     ...studentGetters,
@@ -84,9 +84,5 @@ export default new Vuex.Store({
     ...teacherGetters,
     ...reasonGetters,
     ...matchesGetters,
-    screeningStudents: (state) => state.students.filter((student) => student.status.Description === "SCREENING"),
-    unmatchedStudents: (state) => state.students.filter((student) => student.status.Description === "UNMATCHED"),
-    getStudentByStudentId: (state) => (id) => state.students.find(student => student.StudentID == id),
-    getTeacherByTeacherId: (state) => (id) => state.teachers.find(teacher => teacher.TeacherID == id)
   },
 });

--- a/frontend/src/store/students.js
+++ b/frontend/src/store/students.js
@@ -154,4 +154,14 @@ export const studentMutations = {
 };
 export const studentGetters = {
   students: (state) => state.students,
+  getStudentByStudentId: (state) => (id) =>
+    state.students.find((student) => student.StudentID == id),
+  screeningStudents: (state) =>
+    state.students.filter(
+      (student) => student.status.Description === "SCREENING"
+    ),
+  unmatchedStudents: (state) =>
+    state.students.filter(
+      (student) => student.status.Description === "UNMATCHED"
+    ),
 };


### PR DESCRIPTION
Closes #142. Recommended to review commit by commit.

Also includes two small cleanups:
- Move `teacherGetters` and `studentGetters` out of `store.js`
- Specify `StudentID` and `TeacherID` as `type: Number`

To test:
1. Create a new teacher with no Second Language.
2. Check that the new teacher's Profile displays correctly.