### PR TITLE
[IRRC-104] Fix Status search/filter bug in Teachers.vue

### DIFF
--- a/frontend/src/pages/Teachers.vue
+++ b/frontend/src/pages/Teachers.vue
@@ -71,6 +71,12 @@
           field="status.Description"
           label="Status"
           searchable
+          :custom-search="
+            (object, input) =>
+              object.status.Description.toLowerCase().startsWith(
+                input.toLowerCase()
+              )
+          "
           sortable
         >
           <template slot="searchable" slot-scope="props">

--- a/frontend/src/pages/Teachers.vue
+++ b/frontend/src/pages/Teachers.vue
@@ -67,7 +67,12 @@
           </template>
         </b-table-column>
 
-        <b-table-column field="status" label="Status" searchable sortable>
+        <b-table-column
+          field="status.Description"
+          label="Status"
+          searchable
+          sortable
+        >
           <template slot="searchable" slot-scope="props">
             <b-input
               v-model="props.filters[props.column.field]"


### PR DESCRIPTION
<!-- Name of the Pull Request -->
# [IRRC-104] Fix Status search/filter bug in Teachers.vue
<!-- JIRA Issue Number -->
[IRRC-104](https://bootcamp-irrc.atlassian.net/browse/IRRC-104)

<!-- Please describe the changes in your Pull Request -->
## Description

Fixes status search bug. Instead of "status" as a field, it should instead take "status.Description". Previously, when we search "Dropped Out", "Unmatched" etc, entries would not be filtered based on search. 

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Create new teachers if needed - Just make sure there is at least one teacher for each status (dropped out, unmatched, matched). 
2. Go to the overall Teachers page and click to sort by status
3. In the search bar under "Status", type in a status. Teachers with that status should now be displayed closest to the top of the table. This should work regardless of whether the search string is lower/uppercase 
