### PR TITLE
[IRRC-21 (story)] Enhancing suggested teacher modal 

### DIFF
--- a/frontend/src/components/modals/ModalSuggestedTeachers.vue
+++ b/frontend/src/components/modals/ModalSuggestedTeachers.vue
@@ -9,9 +9,11 @@
     </h4>
     <div class="card-image">
       <b-table
-        v-bind:data="teachersData"
+        v-bind:data="tableData"
         :columns="teachersColumns"
         :selected.sync="selectedTeacher"
+        :backendFiltering="true"
+        @filters-change="onFilter"
       >
       </b-table>
       <b-button class="button field is-blue" @click="handleClose">
@@ -22,6 +24,7 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex";
 export default {
   name: "SuggestedTeachersModal",
   props: {
@@ -42,8 +45,20 @@ export default {
       default: "",
     },
   },
+  computed: {
+    ...mapGetters(["suggestedTeachers"]),
+    tableData() {
+      if (this.isSearchingTeacher) {
+        return this.searchedTeachers;
+      } else {
+        return this.teachersData;
+      }
+    },
+  },
   data() {
     return {
+      isSearchingTeacher: false,
+      searchedTeachers: [],
       teachersColumns: [
         {
           field: "FullName",
@@ -71,6 +86,24 @@ export default {
     handleClose() {
       this.$emit("selectTeacher", this.selectedTeacher);
       this.$emit("close");
+    },
+    onFilter(fields) {
+      if (fields.FullName || fields.Source) {
+        this.isSearchingTeacher = true;
+        this.searchedTeachers = this.suggestedTeachers(-1, fields).map(
+          (teacher) => {
+            return {
+              ...teacher,
+              NativeLanguage: `${teacher.nativeLanguage.NativeLanguage}`,
+              SecondLanguage: `${teacher.secondLanguage.NativeLanguage}`,
+              Status: `${teacher.status.Description}`,
+            };
+          }
+        );
+      } else {
+        this.isSearchingTeacher = false;
+        this.searchedTeachers = [];
+      }
     },
   },
 };

--- a/frontend/src/components/modals/ModalSuggestedTeachers.vue
+++ b/frontend/src/components/modals/ModalSuggestedTeachers.vue
@@ -92,6 +92,10 @@ export default {
         this.isSearchingTeacher = true;
         this.searchedTeachers = this.suggestedTeachers(-1, fields).map(
           (teacher) => {
+            if (teacher.secondLanguage === null) {
+              teacher.secondLanguage = {};
+              teacher.secondLanguage.SecondLanguage = "";
+            }
             return {
               ...teacher,
               NativeLanguage: `${teacher.nativeLanguage.NativeLanguage}`,

--- a/frontend/src/components/statusCards/StatusCardUnmatched.vue
+++ b/frontend/src/components/statusCards/StatusCardUnmatched.vue
@@ -119,6 +119,10 @@ export default {
   computed: {
     suggestedTeachersData() {
       return this.suggestedTeachers(this.studentID).map((teacher) => {
+        if (teacher.secondLanguage === null) {
+          teacher.secondLanguage = {};
+          teacher.secondLanguage.SecondLanguage = "";
+        }
         return {
           ...teacher,
           NativeLanguage: `${teacher.nativeLanguage.NativeLanguage}`,

--- a/frontend/src/store/teachers.js
+++ b/frontend/src/store/teachers.js
@@ -113,7 +113,22 @@ export const teacherGetters = {
   },
 
   suggestedTeachers(state) {
-    return (studentId) => {
+    return (studentId, filters) => {
+      if (filters) {
+        return state.teachers.filter((teacher) => {
+          let nameMatch = true;
+          let sourceMatch = true;
+          if (filters.FullName) {
+            nameMatch = new RegExp(filters.FullName, "ig").test(
+              teacher.FullName
+            );
+          }
+          if (filters.Source) {
+            sourceMatch = new RegExp(filters.Source, "ig").test(teacher.Source);
+          }
+          return nameMatch && sourceMatch;
+        });
+      }
       // 1. Find the student using the ID
       const student = state.students.find(
         (student) => parseInt(student.StudentID) === parseInt(studentId)


### PR DESCRIPTION
<!-- Name of the Pull Request -->
# modified teacher searching modal to allow for filtering (e.g. name, source) across ALL teachers. 

<!-- JIRA Issue Number -->
[IRRC-21](https://bootcamp-irrc.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=IRRC&selectedIssue=IRRC-21)

<!-- Please describe the changes in your Pull Request -->
## Description
Modified the suggested teachers modal to allow searching for teachers by name and source outside of the original list of 5 suggested teachers. Previously, search only allowed for filtering within the list of 5. 

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Make sure there is a student that is unmatched
2. Have at least 2 teachers in the database. One of those teachers should not have a matching Language 1 or Language 2 (Native Language and Second Language) with the student, i.e. that teacher should not show up in the list of 5suggested teachers.
3. Click on the student profile for the unmatched student, and click on the "select match" button. 
4. Modal should pop up with only the teacher(s) that have matching Language 1 or language 2 with the student
5. Search for another teacher by name or source, and teachers not in the original list should show up 
