### PR TITLE
[IRRC-109 (part 1)] Modified suggested teacher modal + modified matching.vue to use modal component

### DIFF
--- a/frontend/src/components/modals/ModalSuggestedTeachers.vue
+++ b/frontend/src/components/modals/ModalSuggestedTeachers.vue
@@ -51,16 +51,20 @@ export default {
           searchable: true,
         },
         {
+          field: "Status",
+          label: "Teacher Status",
+        },
+        {
           field: "NativeLanguage",
-          label: "Native Language",
+          label: "Language 1",
         },
         {
           field: "SecondLanguage",
-          label: "Second Language",
+          label: "Language 2",
         },
         {
           field: "Source",
-          label: "Company",
+          label: "Source",
           searchable: true,
         },
       ],

--- a/frontend/src/pages/Matching.vue
+++ b/frontend/src/pages/Matching.vue
@@ -15,7 +15,7 @@
           :sort-icon-size="sortIconSize"
           :sortDirection="sortDirection"
           :selected.sync="selectedStudent"
-          @click="isComponentModalActive = true"
+          @click="toggleSuggestedTeachersModal()"
         >
           <!-- date column -->
 
@@ -245,42 +245,22 @@
         >
         </b-table>
       </section>
-      <section>
-        <b-modal v-model="isComponentModalActive" :width="640" scroll="keep">
-          <div class="card">
-            <h2>Select a teacher for student:</h2>
-            <h4>Student Name: {{ selectedStudent.FullName }}</h4>
-            <h4>Teacher Name: {{ selectedTeacher.FullName }}</h4>
-            <div class="card-image">
-              <b-table
-                :data="teachersData"
-                :columns="teachersColumns"
-                :selected.sync="selectedTeacher"
-              >
-              </b-table>
-              <b-button class="button field is-blue" @click="addMatchedPair()">
-                <span>Match temporarily</span>
-              </b-button>
-            </div>
-          </div>
-        </b-modal>
-      </section>
     </div>
   </Page>
 </template>
 
 <script>
+import Vue from "vue";
 import PageHeader from "../components/PageHeader.vue";
 import Page from "../components/Page.vue";
 import { mapGetters, mapActions, mapState } from "vuex";
 import Status from "../components/Status.vue";
+import SuggestedTeachersModal from "../components/modals/ModalSuggestedTeachers.vue";
 
 export default {
   data() {
     return {
-      isComponentModalActive: false,
       selectedStudent: {},
-      selectedTeacher: {},
       matchedPairs: [],
       selectedMatches: [],
       studentsColumns: [
@@ -412,16 +392,32 @@ export default {
       "getAllTeachers",
       "matchStudentTeacherPairs",
     ]),
-    addMatchedPair() {
+    toggleSuggestedTeachersModal() {
+      Vue.nextTick().then(() => {
+        this.$buefy.modal.open({
+          parent: this,
+          component: SuggestedTeachersModal,
+          props: {
+            teachersData: this.teachersData,
+            matchButtonText: "Match Temporarily",
+            studentName: this.selectedStudent.FullName,
+          },
+          events: {
+            selectTeacher: (teacher) => this.addMatchedPair(teacher),
+          },
+          trapFocus: true,
+          hasModalCard: true,
+        });
+      });
+    },
+    addMatchedPair(teacher) {
       this.matchedPairs.push({
-        TeacherID: this.selectedTeacher.TeacherID,
-        TeacherFullName: this.selectedTeacher.FullName,
+        TeacherID: teacher.TeacherID,
+        TeacherFullName: teacher.FullName,
         StudentID: this.selectedStudent.StudentID,
         StudentFullName: this.selectedStudent.FullName,
       });
       this.selectedStudent = {};
-      this.selectedTeacher = {};
-      this.isComponentModalActive = false;
     },
     unmatchSelected() {
       this.matchedPairs = this.matchedPairs.filter(
@@ -581,3 +577,4 @@ button.button.field.is-white {
   padding: 30px;
 }
 </style>
+s


### PR DESCRIPTION
… changed labels for the modal per client requests

<!-- Name of the Pull Request -->
Modified suggested teachers modal + modified matching.vue to use the same component

<!-- JIRA Issue Number -->
[IRRC-109](https://bootcamp-irrc.atlassian.net/browse/IRRC-109)

<!-- Please describe the changes in your Pull Request -->
- Changed suggested teacher modal labels (company -> source, native language -> language 1... etc)
- Added in another column to show teacher status (may change this to a pop-up or tag of sorts down the line...)
- Edited matching.vue to use the suggested teachers modal component

Note: Teaching experience column to be added later. 

This change implements essential features.

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Have at least one students+teacher pair be ready to confirm match on matching page
2. Click on student row in the matching table, suggested teacher modal should show up with the right teacher. Click Match temporarily. 
3. [For info] the suggested teacher modal should have their column names changed, as well as a new column for teacher status. Can also check that this change appears in the Student Profile pages once you Select Match
