### PR TITLE
Fixing bug where teachers with no secondlanguage cannot be displayed on EditTeacher

### DIFF
--- a/frontend/src/store/teachers.js
+++ b/frontend/src/store/teachers.js
@@ -109,7 +109,9 @@ export const teacherGetters = {
     return state.teachers;
   },
   getTeacherByTeacherId: (state) => (id) => {
-    return state.teachers.find((teacher) => teacher.TeacherID == id);
+    const teacher = state.teachers.find((teacher) => teacher.TeacherID == id);
+    const secondLanguage = teacher.secondLanguage || {};
+    return { ...teacher, secondLanguage };
   },
 
   suggestedTeachers(state) {


### PR DESCRIPTION

<!-- Name of the Pull Request -->
<!-- JIRA Issue Number -->
fixes bug #155 

<!-- Please describe the changes in your Pull Request -->
## Description

changed getTeacherByTeacherId in store.js 
- when secondLanguage is null, we copy the teacher object obtained by filtering the teachers state to a new object and assign new value of {} to secondLanguage 
- This addresses bug 155 by ensuring that the field in our UI will be left blank instead of encountering an error where EditTeacher tries to display secondLanguage.NativeLanguage (cannot read property when secondLanguage is null to begin with). 

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Create a new Teacher with only Language 1, no Language 2 
2. Go to EditTeacher (/edit-teacher/:id) 
3. See if the teacher's details appear in the form fields
