### PR TITLE
Restore Edit links in Student/Teacher profiles

### DIFF
--- a/frontend/src/components/ProfileCard.vue
+++ b/frontend/src/components/ProfileCard.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="card">
-    <div class="edit-container">Edit</div>
+    <div class="edit-container">
+      <router-link v-if="isTeacher" :to="'/edit-teacher/' + profile.id"
+        >Edit</router-link
+      >
+      <router-link v-else :to="'/edit-student/' + profile.id">Edit</router-link>
+    </div>
     <div class="profile-grid">
       <img v-if="isTeacher" src="../assets/teacher.png" />
       <img v-else src="../assets/images/student.png" />
@@ -81,6 +86,7 @@ export default {
       type: Object,
       default: function () {
         return {
+          id: 0,
           name: "Default Name",
           contact: "9123 4567",
           dateJoined: "Sept 07 2020",

--- a/frontend/src/pages/StudentProfile.vue
+++ b/frontend/src/pages/StudentProfile.vue
@@ -4,6 +4,7 @@
       <div class="student-profile-left">
         <ProfileCard
           v-bind:profile="{
+            id: studentData.StudentID,
             name: studentData.FullName,
             contact: studentData.PhoneNumber,
             source: studentData.Source,

--- a/frontend/src/pages/TeacherProfile.vue
+++ b/frontend/src/pages/TeacherProfile.vue
@@ -4,6 +4,7 @@
       <div class="teacher-profile-left">
         <ProfileCard
           v-bind:profile="{
+            id: teacherData.TeacherID,
             name: teacherData.FullName,
             contact: teacherData.PhoneNumber,
             source: teacherData.Source,


### PR DESCRIPTION
The "Edit" link was not working on Student/Teacher profiles. The diff in #110 must have been undone.

To test:
- Create a new Student/Teacher
- Try to edit the new Student/Teacher by clicking "Edit" from their individual profiles