### PR TITLE
Display all teachers if no perfect match for selected student

### DIFF
--- a/frontend/src/components/modals/ModalSuggestedTeachers.vue
+++ b/frontend/src/components/modals/ModalSuggestedTeachers.vue
@@ -7,6 +7,7 @@
     <h4>
       Teacher Name: <strong>{{ selectedTeacher.FullName }}</strong>
     </h4>
+    <h4 v-if="displayText"><br>Showing all teachers because there's no perfect match for this student<br></h4>
     <div class="card-image">
       <b-table
         v-bind:data="tableData"
@@ -14,6 +15,7 @@
         :selected.sync="selectedTeacher"
         :backendFiltering="true"
         @filters-change="onFilter"
+        :sticky-header=true
       >
       </b-table>
       <b-button class="button field is-blue" @click="handleClose">
@@ -24,7 +26,7 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapActions } from "vuex";
 export default {
   name: "SuggestedTeachersModal",
   props: {
@@ -51,13 +53,19 @@ export default {
       if (this.isSearchingTeacher) {
         return this.searchedTeachers;
       } else {
-        return this.teachersData;
+        if (this.teachersData.length > 0) {
+          return this.teachersData;
+        } else {
+          this.displayText = true;
+          return this.allTeachers()
+        }
       }
     },
   },
   data() {
     return {
       isSearchingTeacher: false,
+      displayText: false,
       searchedTeachers: [],
       teachersColumns: [
         {
@@ -84,9 +92,12 @@ export default {
         },
       ],
       selectedTeacher: {},
+      myTeachers: [],
     };
   },
   methods: {
+    ...mapGetters(["teachers"]),
+
     handleClose() {
       this.$emit("selectTeacher", this.selectedTeacher);
       this.$emit("close");
@@ -110,9 +121,27 @@ export default {
         );
       } else {
         this.isSearchingTeacher = false;
-        this.searchedTeachers = [];
+        this.searchedTeachers = []
       }
     },
+    allTeachers() {
+      this.myTeachers = this.teachers();
+
+      return this.myTeachers.map(
+          (teacher) => {
+            if (teacher.secondLanguage === null) {
+              teacher.secondLanguage = {};
+              teacher.secondLanguage.SecondLanguage = "";
+            }
+            return {
+              ...teacher,
+              NativeLanguage: `${teacher.nativeLanguage.NativeLanguage}`,
+              SecondLanguage: `${teacher.secondLanguage.NativeLanguage}`,
+              Status: `${teacher.status.Description}`,
+            };
+          }
+        )
+    }
   },
 };
 </script>

--- a/frontend/src/components/modals/ModalSuggestedTeachers.vue
+++ b/frontend/src/components/modals/ModalSuggestedTeachers.vue
@@ -7,7 +7,7 @@
     <h4>
       Teacher Name: <strong>{{ selectedTeacher.FullName }}</strong>
     </h4>
-    <h4 v-if="displayText"><br>Showing all teachers because there's no perfect match for this student<br></h4>
+    <h4 v-if="!isSearchingTeachers && teachersData.length === 0"><br>Showing all teachers because there's no perfect match for this student<br></h4>
     <div class="card-image">
       <b-table
         v-bind:data="tableData"


### PR DESCRIPTION
<!-- Name of the Pull Request -->
# Display all teachers if no perfect match for selected student

<!-- JIRA Issue Number -->
Closes #167 

<!-- Please describe the changes in your Pull Request -->
## Description

1. Display all teachers in the suggested teachers modal if there is no suggested teacher (based on matching logic), for the student selected. Prior to this, the suggested teachers modal was blank, which meant that the user would need to remember the list of teachers and search by the teacher's name.

2. Made the suggested teacher's modal scroll-able 

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Create a new Student with a completely unique Language 1 (this will help make sure there is no suggested teachers matched to them)
2. Bring the student from Screening -> Matching
3. Click on that student on the Matching table. You should see the full list of suggested teachers, along with the text ''Showing all teachers because there's no perfect match for this student". 
