### PR TITLE
[Bug] Add showAddLanguage method back to NewTeacher.vue

### DIFF
--- a/frontend/src/pages/NewTeacher.vue
+++ b/frontend/src/pages/NewTeacher.vue
@@ -384,6 +384,23 @@ export default {
       });
     },
 
+    showAddLanguage() {
+      this.$buefy.dialog.prompt({
+        message: `Add new language`,
+        inputAttrs: {
+          placeholder: "e.g. Italian",
+          maxlength: 255,
+          value: this.nativeLanguage,
+        },
+        confirmText: "Add",
+        onConfirm: (value) => {
+          this.$refs.languageComplete.setSelected({
+            NativeLanguage: value,
+          });
+        },
+      });
+    },
+
     showAddSecondLanguage() {
       this.$buefy.dialog.prompt({
         message: `Add new language`,


### PR DESCRIPTION
<!-- Name of the Pull Request -->
# Add showAddLanguage method back to NewTeacher.vue

<!-- Please describe the changes in your Pull Request -->
## Description

The `showAddLanguage` method was wrongly deleted from `NewTeacher.vue` in #176. Refer to the diff [here](https://github.com/TechLadies/irrc-madwish/compare/a209debff38cc2dca6b3859d49aa0431e7a68198..3b7a1c90ea12c550c0e2a4ec0e73657f85cccc6c#diff-2359155f323b416a35e40d17e6efefffc8882d3372e108f5de9a6c43d214aef2L381-L397) 

This deletion results in the user not having a drop-down list of languages to choose from in trying to create a new teacher. 

This PR adds that method back. 

<!-- Please describe the steps that reviewers can take to test your changes locally -->
## Test Steps

1. Create a new Teacher
2. A drop-down list of languages should appear
3. You should still be able to create a new teacher with no languages / 1 language / 2 language 